### PR TITLE
Guests: WebRTC (WHIP) media ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +68,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive 0.4.0",
+ "asn1-rs-impl 0.1.0",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl 0.2.0",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure 0.13.2",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,7 +161,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -77,7 +198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -150,6 +271,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,12 +300,27 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abaf6da45c74385272ddf00e1ac074c7d8a6c1a1dda376902bd6a427522a8b2c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "blowfish",
  "getrandom 0.3.4",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -197,6 +345,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -230,6 +387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +403,18 @@ checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -340,23 +518,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -375,6 +601,39 @@ dependencies = [
  "pem-rfc7468",
  "zeroize",
 ]
+
+[[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+dependencies = [
+ "asn1-rs 0.5.2",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -405,7 +664,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -415,12 +674,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -471,6 +765,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +810,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -554,7 +879,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -575,6 +900,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -593,6 +919,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -632,6 +959,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio-sys"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,7 +987,7 @@ version = "0.20.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -675,7 +1012,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -697,6 +1034,17 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -854,7 +1202,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -1158,8 +1506,35 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
+
+[[package]]
+name = "interceptor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4705c00485029e738bea8c9505b5ddb1486a8f3627a953e1e77e6abdf5eef90c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rtcp",
+ "rtp",
+ "thiserror 1.0.69",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -1219,7 +1594,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -1289,6 +1664,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1687,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1365,6 +1755,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "webrtc",
 ]
 
 [[package]]
@@ -1396,12 +1787,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1419,6 +1843,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1461,6 +1891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1918,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
 dependencies = [
  "paste",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1517,6 +1980,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +2009,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -1571,6 +2050,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +2075,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1595,7 +2098,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1697,12 +2209,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1711,7 +2237,19 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1727,9 +2265,33 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rml_amf0"
@@ -1777,6 +2339,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtcp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc9f775ff89c5fe7f0cc0abafb7c57688ae25ce688f1a52dd88e277616c76ab2"
+dependencies = [
+ "bytes",
+ "thiserror 1.0.69",
+ "webrtc-util",
+]
+
+[[package]]
+name = "rtp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6870f09b5db96f8b9e7290324673259fd15519ebb7d55acf8e7eb044a9ead6af"
+dependencies = [
+ "bytes",
+ "portable-atomic",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 1.0.69",
+ "webrtc-util",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +2432,32 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdp"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13254db766b17451aced321e7397ebf0a446ef0c8d2942b6e67a95815421093f"
+dependencies = [
+ "rand 0.8.5",
+ "substring",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "semver"
@@ -1827,7 +2492,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1961,6 +2626,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,7 +2692,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -2046,7 +2730,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2069,7 +2753,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -2081,8 +2765,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "crc",
@@ -2123,8 +2807,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -2195,10 +2879,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.4.1"
+name = "stun"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "28fad383a1cc63ae141e84e48eaef44a1063e9d9e55bcb8f51a99b886486e01b"
+dependencies = [
+ "base64 0.21.7",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.5",
+ "ring",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2219,13 +2942,25 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2273,7 +3008,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2284,7 +3019,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2294,6 +3029,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2333,7 +3098,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2346,7 +3111,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2458,7 +3223,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2510,7 +3275,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2569,6 +3334,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "turn"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b000cebd930420ac1ed842c8128e3b3412512dfd5b82657eab035a3f5126acc"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "futures",
+ "log",
+ "md-5",
+ "portable-atomic",
+ "rand 0.8.5",
+ "ring",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "webrtc-util",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +3398,22 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2666,6 +3468,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
 
 [[package]]
 name = "wasi"
@@ -2729,7 +3540,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2770,10 +3581,219 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b3a840e31c969844714f93b5a87e73ee49f3bc2a4094ab9132c69497eb31db"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rcgen",
+ "regex",
+ "ring",
+ "rtcp",
+ "rtp",
+ "rustls",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smol_str",
+ "stun",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "turn",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-dtls",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b7c550f8d35867b72d511640adf5159729b9692899826fe00ba7fa74f0bf70"
+dependencies = [
+ "bytes",
+ "log",
+ "portable-atomic",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-dtls"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e5eedbb0375aa04da93fc3a189b49ed3ed9ee844b6997d5aade14fc3e2c26e"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bincode",
+ "byteorder",
+ "cbc",
+ "ccm",
+ "der-parser 8.2.0",
+ "hkdf",
+ "hmac 0.12.1",
+ "log",
+ "p256",
+ "p384",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rustls",
+ "sec1",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+ "x25519-dalek",
+ "x509-parser",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4f0ca6d4df8d1bdd34eece61b51b62540840b7a000397bcfb53a7bfcf347c8"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0804694f3b2acfdff48f6df217979b13cb0a00377c63b5effd111daaee7e8c4"
+dependencies = [
+ "log",
+ "socket2 0.5.10",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c15b20e98167b22949abc1c20eca7c6d814307d187068fe7a48f0b87a4f6d46"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.8.5",
+ "rtp",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d850daa68639b9d7bb16400676e97525d1e52b15b4928240ae2ba0e849817a5"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbec5da43a62c228d321d93fb12cc9b4d9c03c9b736b0c215be89d8bd0774cfe"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac 0.12.1",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha1",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8d9bc631768958ed97b8d68b5d301e63054ae90b09083d43e2fefb939fd77e"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "portable-atomic",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -2785,6 +3805,28 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2807,7 +3849,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2818,7 +3860,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2852,6 +3894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3032,7 +4083,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3048,7 +4099,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3060,7 +4111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3097,6 +4148,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,8 +4205,8 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "synstructure",
+ "syn 2.0.117",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -3136,7 +4226,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3156,8 +4246,8 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "synstructure",
+ "syn 2.0.117",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -3165,6 +4255,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3196,7 +4300,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -26,6 +26,7 @@ hex = "0.4"
 bcrypt = "0.17"
 rml_rtmp = "0.8"
 bytes = "1"
+webrtc = "0.11"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/api/src/guest_webrtc.rs
+++ b/crates/api/src/guest_webrtc.rs
@@ -1,0 +1,450 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! WebRTC (WHIP) guest ingest.
+//!
+//! A guest publishes camera/mic over WebRTC. We terminate the peer with
+//! webrtc-rs, forward the guest's RTP to local UDP ports, and run an FFmpeg
+//! subprocess that reads them via an SDP, normalizes to the output canvas, and
+//! feeds FLV into the source's media relay — so a guest becomes an ordinary,
+//! switchable Source alongside RTMP/SRT/media-file sources.
+//!
+//! The live media path can only be verified against a real browser (and, off-LAN,
+//! a TURN server); see `docs/guests-webrtc.md`.
+
+use bytes::Bytes;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::Arc;
+use tokio::io::AsyncReadExt;
+use tokio::net::UdpSocket;
+use tokio::process::Command;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use webrtc::api::interceptor_registry::register_default_interceptors;
+use webrtc::api::media_engine::{MediaEngine, MIME_TYPE_OPUS, MIME_TYPE_VP8};
+use webrtc::api::APIBuilder;
+use webrtc::ice_transport::ice_server::RTCIceServer;
+use webrtc::interceptor::registry::Registry;
+use webrtc::peer_connection::configuration::RTCConfiguration;
+use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
+use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
+use webrtc::peer_connection::RTCPeerConnection;
+use webrtc::rtp_transceiver::rtp_codec::{
+    RTCRtpCodecCapability, RTCRtpCodecParameters, RTPCodecType,
+};
+use webrtc::util::Marshal;
+
+use crate::routes::output::OutputConfig;
+use crate::state::AppState;
+
+/// Fixed payload types we rewrite forwarded RTP to, so the FFmpeg SDP is static.
+const VP8_PT: u8 = 96;
+const OPUS_PT: u8 = 111;
+
+/// Local UDP port allocator for the FFmpeg <- RTP bridge (video, audio per guest).
+static PORT_COUNTER: AtomicU16 = AtomicU16::new(0);
+
+fn alloc_ports() -> (u16, u16) {
+    let n = PORT_COUNTER.fetch_add(1, Ordering::Relaxed) % 1000;
+    let base = 41000 + n * 2;
+    (base, base + 1)
+}
+
+/// Accept a guest's WHIP offer, wire up the RTP -> FFmpeg -> relay bridge, and
+/// return the SDP answer. The source row must already exist (created by the
+/// caller); on any error the caller should tear it down.
+pub async fn start_guest_ingest(
+    state: Arc<AppState>,
+    source_id: Uuid,
+    offer_sdp: String,
+) -> Result<String, String> {
+    let (video_port, audio_port) = alloc_ports();
+
+    let pc = build_peer().await?;
+
+    // Forward the guest's RTP to the FFmpeg UDP ports, rewriting the payload
+    // type to our fixed values so the SDP FFmpeg reads is deterministic.
+    let forward = Arc::new(
+        UdpSocket::bind("127.0.0.1:0")
+            .await
+            .map_err(|e| format!("udp bind: {}", e))?,
+    );
+    let fwd = forward.clone();
+    pc.on_track(Box::new(move |track, _receiver, _transceiver| {
+        let fwd = fwd.clone();
+        Box::pin(async move {
+            let is_video = track.kind() == RTPCodecType::Video;
+            let (pt, port) = if is_video {
+                (VP8_PT, video_port)
+            } else {
+                (OPUS_PT, audio_port)
+            };
+            let addr = format!("127.0.0.1:{}", port);
+            while let Ok((mut packet, _)) = track.read_rtp().await {
+                packet.header.payload_type = pt;
+                if let Ok(raw) = packet.marshal() {
+                    let _ = fwd.send_to(&raw, &addr).await;
+                }
+            }
+        })
+    }));
+
+    // Tear the guest source down when the peer drops.
+    let st = state.clone();
+    pc.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        let st = st.clone();
+        Box::pin(async move {
+            tracing::info!("guest {} peer state: {:?}", source_id, s);
+            if matches!(
+                s,
+                RTCPeerConnectionState::Failed
+                    | RTCPeerConnectionState::Disconnected
+                    | RTCPeerConnectionState::Closed
+            ) {
+                stop_guest_ingest(&st, &source_id).await;
+            }
+        })
+    }));
+
+    // Validate + apply the offer before spending any FFmpeg/transcode resources.
+    let offer = RTCSessionDescription::offer(offer_sdp).map_err(|e| format!("bad offer: {}", e))?;
+    pc.set_remote_description(offer)
+        .await
+        .map_err(|e| format!("set remote description: {}", e))?;
+
+    // Offer is good — bring up the FFmpeg bridge so the ports are bound before
+    // media starts flowing once the guest connects.
+    let public_tx = state.get_or_create_media_relay(source_id).await;
+    start_ffmpeg(state.clone(), source_id, video_port, audio_port, public_tx).await?;
+
+    let answer = pc
+        .create_answer(None)
+        .await
+        .map_err(|e| format!("create answer: {}", e))?;
+    let mut gather = pc.gathering_complete_promise().await;
+    pc.set_local_description(answer)
+        .await
+        .map_err(|e| format!("set local description: {}", e))?;
+    let _ = gather.recv().await;
+
+    let sdp = pc
+        .local_description()
+        .await
+        .ok_or("no local description after gathering")?
+        .sdp;
+
+    state.guest_peers.write().await.insert(source_id, pc);
+    Ok(sdp)
+}
+
+async fn build_peer() -> Result<Arc<RTCPeerConnection>, String> {
+    let mut m = MediaEngine::default();
+    m.register_codec(
+        RTCRtpCodecParameters {
+            capability: RTCRtpCodecCapability {
+                mime_type: MIME_TYPE_VP8.to_owned(),
+                clock_rate: 90000,
+                channels: 0,
+                sdp_fmtp_line: String::new(),
+                rtcp_feedback: vec![],
+            },
+            payload_type: VP8_PT,
+            ..Default::default()
+        },
+        RTPCodecType::Video,
+    )
+    .map_err(|e| format!("register vp8: {}", e))?;
+    m.register_codec(
+        RTCRtpCodecParameters {
+            capability: RTCRtpCodecCapability {
+                mime_type: MIME_TYPE_OPUS.to_owned(),
+                clock_rate: 48000,
+                channels: 2,
+                sdp_fmtp_line: "minptime=10;useinbandfec=1".to_owned(),
+                rtcp_feedback: vec![],
+            },
+            payload_type: OPUS_PT,
+            ..Default::default()
+        },
+        RTPCodecType::Audio,
+    )
+    .map_err(|e| format!("register opus: {}", e))?;
+
+    let mut registry = Registry::new();
+    registry = register_default_interceptors(registry, &mut m)
+        .map_err(|e| format!("interceptors: {}", e))?;
+
+    let api = APIBuilder::new()
+        .with_media_engine(m)
+        .with_interceptor_registry(registry)
+        .build();
+
+    let config = RTCConfiguration {
+        ice_servers: vec![RTCIceServer {
+            urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let pc = api
+        .new_peer_connection(config)
+        .await
+        .map_err(|e| format!("new peer connection: {}", e))?;
+
+    Ok(Arc::new(pc))
+}
+
+async fn start_ffmpeg(
+    state: Arc<AppState>,
+    source_id: Uuid,
+    video_port: u16,
+    audio_port: u16,
+    public_tx: broadcast::Sender<Bytes>,
+) -> Result<(), String> {
+    let cfg = load_output_config(&state).await;
+
+    let sdp = format!(
+        "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=muxshed-guest\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\n\
+         m=video {vp} RTP/AVP {vpt}\r\na=rtpmap:{vpt} VP8/90000\r\n\
+         m=audio {ap} RTP/AVP {opt}\r\na=rtpmap:{opt} opus/48000/2\r\n",
+        vp = video_port,
+        vpt = VP8_PT,
+        ap = audio_port,
+        opt = OPUS_PT,
+    );
+    let data_dir = state.config.read().await.data_dir.clone();
+    tokio::fs::create_dir_all(&data_dir).await.ok();
+    let sdp_path = data_dir.join(format!("guest-{}.sdp", source_id));
+    tokio::fs::write(&sdp_path, sdp)
+        .await
+        .map_err(|e| format!("write sdp: {}", e))?;
+    let sdp_arg = sdp_path.to_string_lossy().to_string();
+
+    let vf = format!(
+        "scale={}:{}:force_original_aspect_ratio=decrease,pad={}:{}:(ow-iw)/2:(oh-ih)/2:black",
+        cfg.width, cfg.height, cfg.width, cfg.height
+    );
+    let bv = format!("{}k", cfg.video_bitrate_kbps);
+    let maxrate = format!("{}k", cfg.video_bitrate_kbps);
+    let bufsize = format!("{}k", cfg.video_bitrate_kbps * 2);
+    let gop = format!("{}", cfg.fps * 2);
+    let fps = format!("{}", cfg.fps);
+    let ba = format!("{}k", cfg.audio_bitrate_kbps);
+
+    let args = vec![
+        "-hide_banner",
+        "-loglevel", "warning",
+        "-protocol_whitelist", "file,crypto,data,rtp,udp",
+        "-fflags", "+genpts",
+        "-i", &sdp_arg,
+        "-vf", &vf,
+        "-c:v", "libx264",
+        "-preset", "veryfast",
+        "-tune", "zerolatency",
+        "-b:v", &bv,
+        "-maxrate", &maxrate,
+        "-bufsize", &bufsize,
+        "-g", &gop,
+        "-r", &fps,
+        "-pix_fmt", "yuv420p",
+        "-c:a", "aac",
+        "-b:a", &ba,
+        "-ar", "48000",
+        "-f", "flv",
+        "-flvflags", "no_duration_filesize",
+        "pipe:1",
+    ];
+
+    tracing::info!(
+        "starting guest ingest ffmpeg for {} (video :{}, audio :{})",
+        source_id, video_port, audio_port
+    );
+
+    let mut child = Command::new("ffmpeg")
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("failed to start guest ffmpeg: {}", e))?;
+
+    let stdout = child.stdout.take().ok_or("no stdout")?;
+
+    if let Some(stderr) = child.stderr.take() {
+        let sid = source_id;
+        tokio::spawn(async move {
+            let mut reader = tokio::io::BufReader::new(stderr);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut line).await {
+                    Ok(0) => break,
+                    Ok(_) => tracing::debug!("guest [{}]: {}", sid, line.trim()),
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+
+    {
+        let mut normalizers = state.source_normalizers.write().await;
+        if let Some(mut old) = normalizers.remove(&source_id) {
+            let _ = old.kill().await;
+        }
+        normalizers.insert(source_id, child);
+    }
+
+    state
+        .source_states
+        .write()
+        .await
+        .insert(source_id, muxshed_common::SourceState::Connecting);
+    let _ = state.ws_tx.send(muxshed_common::WsEvent::SourceState {
+        id: source_id,
+        state: muxshed_common::SourceState::Connecting,
+    });
+
+    tokio::spawn(async move {
+        read_flv_output(source_id, stdout, public_tx, state).await;
+    });
+
+    Ok(())
+}
+
+async fn read_flv_output(
+    source_id: Uuid,
+    mut stdout: tokio::process::ChildStdout,
+    public_tx: broadcast::Sender<Bytes>,
+    state: Arc<AppState>,
+) {
+    let mut header = [0u8; 13];
+    if stdout.read_exact(&mut header).await.is_err() {
+        tracing::warn!("guest: failed to read FLV header for {}", source_id);
+        return;
+    }
+
+    let mut frame_count: u64 = 0;
+
+    loop {
+        let mut tag_header = [0u8; 11];
+        if stdout.read_exact(&mut tag_header).await.is_err() {
+            break;
+        }
+
+        let tag_type = tag_header[0];
+        let data_size = ((tag_header[1] as u32) << 16)
+            | ((tag_header[2] as u32) << 8)
+            | (tag_header[3] as u32);
+
+        let mut data = vec![0u8; data_size as usize];
+        if stdout.read_exact(&mut data).await.is_err() {
+            break;
+        }
+
+        let mut prev_size = [0u8; 4];
+        if stdout.read_exact(&mut prev_size).await.is_err() {
+            break;
+        }
+
+        let total = 11 + data_size as usize + 4;
+        let mut tag_buf = Vec::with_capacity(total);
+        tag_buf.extend_from_slice(&tag_header);
+        tag_buf.extend_from_slice(&data);
+        tag_buf.extend_from_slice(&prev_size);
+        let tag = Bytes::from(tag_buf);
+
+        if tag_type == 9 && !data.is_empty() {
+            let avc_packet_type = if data.len() > 1 { data[1] } else { 255 };
+            let frame_type = (data[0] >> 4) & 0x0F;
+            if avc_packet_type == 0 {
+                let mut headers = state.sequence_headers.write().await;
+                headers.entry(source_id).or_default().video = Some(tag.clone());
+            } else if frame_type == 1 {
+                let mut headers = state.sequence_headers.write().await;
+                if let Some(entry) = headers.get_mut(&source_id) {
+                    entry.last_keyframe = Some(tag.clone());
+                }
+            }
+        } else if tag_type == 8 && !data.is_empty() {
+            let aac_packet_type = if data.len() > 1 { data[1] } else { 255 };
+            if aac_packet_type == 0 {
+                let mut headers = state.sequence_headers.write().await;
+                headers.entry(source_id).or_default().audio = Some(tag.clone());
+            }
+        }
+
+        if frame_count == 0 {
+            state
+                .source_states
+                .write()
+                .await
+                .insert(source_id, muxshed_common::SourceState::Live);
+            let _ = state.ws_tx.send(muxshed_common::WsEvent::SourceState {
+                id: source_id,
+                state: muxshed_common::SourceState::Live,
+            });
+            // Mark the guest record connected now that media is flowing.
+            let _ = sqlx::query("UPDATE guests SET status = 'connected' WHERE source_id = ?")
+                .bind(source_id.to_string())
+                .execute(&state.db)
+                .await;
+            tracing::info!("guest: source {} is live", source_id);
+        }
+
+        let _ = public_tx.send(tag);
+        frame_count += 1;
+    }
+
+    tracing::info!("guest: ended for {} after {} frames", source_id, frame_count);
+}
+
+/// Tear down a guest's ingest: stop FFmpeg, close the peer, drop the ephemeral
+/// source row, and reset the guest record.
+pub async fn stop_guest_ingest(state: &AppState, source_id: &Uuid) {
+    {
+        let mut normalizers = state.source_normalizers.write().await;
+        if let Some(mut child) = normalizers.remove(source_id) {
+            let _ = child.kill().await;
+        }
+    }
+    if let Some(pc) = state.guest_peers.write().await.remove(source_id) {
+        let _ = pc.close().await;
+    }
+    state.remove_media_relay(source_id).await;
+    state.sequence_headers.write().await.remove(source_id);
+    state
+        .source_states
+        .write()
+        .await
+        .insert(*source_id, muxshed_common::SourceState::Disconnected);
+    let _ = state.ws_tx.send(muxshed_common::WsEvent::SourceState {
+        id: *source_id,
+        state: muxshed_common::SourceState::Disconnected,
+    });
+
+    let sid = source_id.to_string();
+    let _ = sqlx::query("DELETE FROM sources WHERE id = ?")
+        .bind(&sid)
+        .execute(&state.db)
+        .await;
+    let _ = sqlx::query("UPDATE guests SET status = 'left', source_id = NULL WHERE source_id = ?")
+        .bind(&sid)
+        .execute(&state.db)
+        .await;
+
+    let data_dir = state.config.read().await.data_dir.clone();
+    let _ = tokio::fs::remove_file(data_dir.join(format!("guest-{}.sdp", source_id))).await;
+}
+
+async fn load_output_config(state: &AppState) -> OutputConfig {
+    sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key = 'output_config'")
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|(json,)| serde_json::from_str(&json).ok())
+        .unwrap_or_default()
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod auth;
 pub mod channel_hls;
 pub mod egress;
+pub mod guest_webrtc;
 pub mod media_player;
 pub mod media_probe;
 pub mod source_normalizer;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -74,6 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         media_players: RwLock::new(std::collections::HashMap::new()),
         source_normalizers: RwLock::new(std::collections::HashMap::new()),
         srt_listeners: RwLock::new(std::collections::HashMap::new()),
+        guest_peers: RwLock::new(std::collections::HashMap::new()),
         program_tx,
         program_source: program_source_tx,
         preview_source: RwLock::new(None),

--- a/crates/api/src/routes/guests.rs
+++ b/crates/api/src/routes/guests.rs
@@ -135,32 +135,66 @@ pub async fn public_info(
 
 /// WHIP endpoint — a guest publishes their camera/mic here over WebRTC.
 ///
-/// The WebRTC media path (webrtc-rs peer → RTP → ffmpeg → Source) is the next
-/// focused build; see `docs/guests-webrtc.md`. For now this validates the token
-/// and reports that ingest is not yet enabled so the join page can degrade
-/// gracefully. The route and contract are stable.
+/// Creates an ephemeral `web_rtc` Source for the guest, terminates the peer, and
+/// bridges the guest's RTP into the media relay via FFmpeg (see
+/// `crate::guest_webrtc`). Returns the SDP answer per the WHIP spec. The live
+/// media path is verifiable only against a real browser; see `docs/guests-webrtc.md`.
 pub async fn whip(
     State(state): State<Arc<AppState>>,
     Path(token): Path<String>,
-    _offer: String,
+    offer: String,
 ) -> Response {
-    let exists = sqlx::query_as::<_, (String,)>("SELECT id FROM guests WHERE token = ?")
+    let guest = sqlx::query_as::<_, (String,)>("SELECT name FROM guests WHERE token = ?")
         .bind(&token)
         .fetch_optional(&state.db)
         .await
         .ok()
         .flatten();
 
-    if exists.is_none() {
+    let Some((name,)) = guest else {
         return (StatusCode::NOT_FOUND, "guest link not found").into_response();
+    };
+
+    // Ephemeral source row so the guest appears in the switcher while connected.
+    let source_id = Uuid::new_v4();
+    let kind = muxshed_common::SourceKind::WebRtc {
+        token: token.clone(),
+    };
+    let kind_json = match serde_json::to_string(&kind) {
+        Ok(j) => j,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+
+    if sqlx::query("INSERT INTO sources (id, name, kind) VALUES (?, ?, ?)")
+        .bind(source_id.to_string())
+        .bind(format!("{} (guest)", name))
+        .bind(&kind_json)
+        .execute(&state.db)
+        .await
+        .is_err()
+    {
+        return (StatusCode::INTERNAL_SERVER_ERROR, "could not create source").into_response();
     }
 
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        [(header::CONTENT_TYPE, "application/json")],
-        r#"{"error":{"code":"WEBRTC_NOT_READY","message":"WebRTC guest ingest is not yet enabled in this build"}}"#,
-    )
-        .into_response()
+    let _ = sqlx::query("UPDATE guests SET status = 'connecting', source_id = ? WHERE token = ?")
+        .bind(source_id.to_string())
+        .bind(&token)
+        .execute(&state.db)
+        .await;
+
+    match crate::guest_webrtc::start_guest_ingest(state.clone(), source_id, offer).await {
+        Ok(answer) => Response::builder()
+            .status(StatusCode::CREATED)
+            .header(header::CONTENT_TYPE, "application/sdp")
+            .header(header::LOCATION, format!("/api/v1/guest/{}/whip", token))
+            .body(axum::body::Body::from(answer))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        Err(e) => {
+            tracing::warn!("guest ingest failed for {}: {}", source_id, e);
+            crate::guest_webrtc::stop_guest_ingest(&state, &source_id).await;
+            (StatusCode::BAD_REQUEST, format!("could not start ingest: {}", e)).into_response()
+        }
+    }
 }
 
 fn generate_token() -> String {

--- a/crates/api/src/routes/sources.rs
+++ b/crates/api/src/routes/sources.rs
@@ -144,12 +144,6 @@ pub async fn delete(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    // Stop any running listener/player before deleting
-    if let Ok(uid) = id.parse::<Uuid>() {
-        crate::srt::stop_srt_listener(&state, &uid).await;
-        crate::media_player::stop_media_playback(&state, &uid).await;
-    }
-
     let result = sqlx::query("DELETE FROM sources WHERE id = ?")
         .bind(&id)
         .execute(&state.db)
@@ -157,6 +151,13 @@ pub async fn delete(
 
     if result.rows_affected() == 0 {
         return Err(MuxshedError::NotFound(format!("source {}", id)).into());
+    }
+
+    // Tear down any running listener/player/guest peer for this source.
+    if let Ok(uid) = id.parse::<Uuid>() {
+        crate::srt::stop_srt_listener(&state, &uid).await;
+        crate::media_player::stop_media_playback(&state, &uid).await;
+        crate::guest_webrtc::stop_guest_ingest(&state, &uid).await;
     }
 
     Ok(StatusCode::NO_CONTENT)

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -24,6 +24,8 @@ pub struct AppState {
     pub media_players: RwLock<HashMap<Uuid, tokio::process::Child>>,
     pub source_normalizers: RwLock<HashMap<Uuid, tokio::process::Child>>,
     pub srt_listeners: RwLock<HashMap<Uuid, tokio::process::Child>>,
+    /// Live WebRTC guest peer connections, kept alive while the guest is connected
+    pub guest_peers: RwLock<HashMap<Uuid, Arc<webrtc::peer_connection::RTCPeerConnection>>>,
     pub egress: EgressManager,
     /// Public Channel HLS output (ffmpeg) for the watch page
     pub channel_hls: ChannelHls,

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -61,6 +61,7 @@ async fn setup() -> (axum::Router<()>, String, Arc<AppState>) {
         media_players: tokio::sync::RwLock::new(std::collections::HashMap::new()),
         source_normalizers: tokio::sync::RwLock::new(std::collections::HashMap::new()),
         srt_listeners: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+        guest_peers: tokio::sync::RwLock::new(std::collections::HashMap::new()),
         program_tx,
         program_source: program_source_tx,
         preview_source: tokio::sync::RwLock::new(None),
@@ -665,7 +666,7 @@ async fn test_guest_whip_unknown_token() {
 }
 
 #[tokio::test]
-async fn test_guest_whip_valid_token_pending() {
+async fn test_guest_whip_malformed_offer() {
     let (app, key, _s) = setup().await;
     let body = invite_guest(&app, &key, "Jo").await;
     let token = body["token"].as_str().unwrap().to_string();
@@ -675,8 +676,9 @@ async fn test_guest_whip_valid_token_pending() {
         .body(Body::from("v=0"))
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
-    // WebRTC ingest not yet enabled — endpoint reports unavailable, not error.
-    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    // A malformed SDP offer is rejected during negotiation; the ephemeral
+    // source is rolled back.
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/docs/guests-webrtc.md
+++ b/docs/guests-webrtc.md
@@ -1,45 +1,51 @@
 # Guests — WebRTC (WHIP) ingest
 
-Status: **foundation shipped; media core is the next focused build.**
+Status: **implemented** (`webrtc` crate 0.11). The live media path is verifiable only
+against a real browser — see the verification note.
 
 Guests join via an unguessable invite link, allow camera/mic in the browser, and
 **WHIP-publish** their stream to the instance. The published media becomes a normal
 **Source** the switcher can cut to — so guests work with everything that already exists
 (scenes, overlays, delay, recording, fan-out).
 
-## What ships today
+## What ships
 
 - **Invite lifecycle** (`crates/api/src/routes/guests.rs`): create / list / delete invites
-  (operator, authed) + a `status` column (`invited` → `connected`) and a `source_id` link.
+  (operator, authed) + a `status` column (`invited` → `connecting` → `connected` → `left`)
+  and a `source_id` link.
 - **Public, token-scoped endpoints** (no auth):
   - `GET /api/v1/guest/{token}` — validate a link, return `{ name, status }`.
-  - `POST /api/v1/guest/{token}/whip` — the WHIP endpoint (see below).
+  - `POST /api/v1/guest/{token}/whip` — WHIP: takes the SDP offer, returns the SDP answer
+    (`201 Created`, `Content-Type: application/sdp`, `Location` header). Malformed offers
+    are rejected `400` and the ephemeral source is rolled back.
+- **The bridge** (`crates/api/src/guest_webrtc.rs`):
+  1. `webrtc-rs` peer (MediaEngine pinned to **VP8 + Opus**), `set_remote_description` →
+     `create_answer` → ICE gather → answer.
+  2. `on_track` reads RTP, rewrites the payload type to fixed values (VP8 96 / Opus 111),
+     and forwards to local UDP ports.
+  3. An **ffmpeg** subprocess reads those ports via a generated SDP
+     (`-protocol_whitelist file,crypto,data,rtp,udp`), normalizes to the output canvas
+     (libx264 + AAC), and feeds FLV into the source's `media_relays` channel — exactly the
+     path `source_normalizer.rs` / `srt.rs` use. Source goes **Live** on the first frame.
+  4. On peer disconnect (or source delete) `stop_guest_ingest` kills ffmpeg, closes the
+     peer, drops the ephemeral source row, clears the relay/headers, and resets the guest
+     to `left`. `SourceState` WS events fire throughout.
 - **Guest join page** (`web/src/routes/guest/[token]`): validates the link, previews
-  camera/mic, builds a real `RTCPeerConnection` offer and POSTs it to the WHIP endpoint.
-  It degrades gracefully while ingest is being built (a `503` shows "coming soon").
+  camera/mic, builds the WHIP offer, applies the answer.
 - **Guests admin page** (`web/src/routes/(app)/guests`): invite, copy link, see status,
   delete.
-- Integration tests cover invite/list/delete, public info (+404), and the WHIP contract.
+- Integration tests cover invite/list/delete, public info (+404), and the WHIP contract
+  (unknown token → 404, malformed offer → 400 with rollback).
 
-The WHIP endpoint currently validates the token and returns `503 WEBRTC_NOT_READY`.
+## Not yet done
 
-## The media core (to build)
-
-Engine reality: Muxshed runs on **ffmpeg + the Rust RTMP relay** (no GStreamer). So:
-
-1. **WHIP handshake** — accept the SDP offer at `POST /guest/{token}/whip`, create a
-   `webrtc-rs` (`webrtc` crate) or `str0m` peer connection with a recvonly video + audio
-   transceiver, set the remote description, create the answer, gather ICE, and return the
-   SDP answer (`201 Created`, `Content-Type: application/sdp`, `Location` header per WHIP).
-2. **Media → Source** — `on_track`: read the guest's RTP (VP8/VP9/H.264 + Opus),
-   depacketize, and pipe into an **ffmpeg** subprocess that remuxes/transcodes to the
-   instance's program format (FLV/H.264 + AAC), then register it as a Source feeding the
-   existing `media_relays` / `program_tx` path (mirror `source_normalizer.rs`).
-3. **Lifecycle** — on connect set `guests.status = 'connected'` and store `source_id`; on
-   disconnect tear the source down and set `status = 'left'`. Emit `SourceState` WS events
-   so the switcher and Companion module light up.
-4. **TURN** — guests behind strict NAT need a TURN relay. Document an optional bundled
-   `coturn`; advertise its ICE servers in the answer. LAN guests work with STUN only.
+- **TURN** — guests behind strict NAT need a TURN relay. Today only a public STUN server is
+  advertised, so LAN/same-network guests connect but off-LAN guests behind symmetric NAT
+  may not. Next: document/bundle an optional `coturn` and advertise its ICE servers.
+- **Codec breadth** — pinned to VP8 + Opus for a deterministic ffmpeg SDP. H.264 guests
+  would need dynamic SDP/PT handling.
+- ffmpeg in the runtime image must have the **VP8 decoder** (libvpx) and **libx264** — both
+  are present in the standard Ubuntu ffmpeg the Docker image installs.
 
 ## Why this shape
 


### PR DESCRIPTION
Builds the guest media core on top of the invite foundation. A guest's browser WHIP-publishes camera/mic; the instance terminates the WebRTC peer and bridges the media into the existing Source pipeline, so a guest is switchable like any RTMP/SRT source (scenes, overlays, delay, recording, fan-out all work).

## How it works
- **`crates/api/src/guest_webrtc.rs`** — `webrtc-rs` peer with the MediaEngine pinned to **VP8 + Opus**. `on_track` reads RTP, rewrites the payload type to fixed values, and forwards to local UDP ports. An **ffmpeg** subprocess reads those ports via a generated SDP, normalizes to the output canvas (libx264 + AAC), and feeds FLV into the source's `media_relays` channel — the same path `source_normalizer.rs` / `srt.rs` use. The source goes **Live** on the first frame.
- **WHIP handler** (`POST /api/v1/guest/{token}/whip`) — creates an ephemeral `web_rtc` source, returns the SDP answer (`201` + `Location`). A malformed offer is rejected `400` and the source is rolled back.
- **Teardown** — peer disconnect (or source delete) kills ffmpeg, closes the peer, drops the ephemeral source row, clears relay/headers, and resets the guest to `left`. `SourceState` WS events fire throughout.
- Adds `AppState.guest_peers` to keep connections alive; new `webrtc = "0.11"` dependency.

## Tests
`cargo test` 21 passed · `cargo clippy --workspace -- -D warnings` clean. Coverage: invite/list/delete, public token info (+404), WHIP contract (unknown token → 404, malformed offer → 400 with rollback).

## Not verifiable headless — needs review
The **live media path can't be exercised in CI** (no real browser/camera/TURN). Please verify end-to-end against a running instance with two devices. Outstanding follow-ups (documented in `docs/guests-webrtc.md`): optional bundled **coturn** for off-LAN guests (only STUN is advertised today), and H.264/codec breadth.