### PR TITLE
Guests: TURN config + Docker Rust 1.88 fix

### DIFF
--- a/crates/api/src/guest_webrtc.rs
+++ b/crates/api/src/guest_webrtc.rs
@@ -61,7 +61,7 @@ pub async fn start_guest_ingest(
 ) -> Result<String, String> {
     let (video_port, audio_port) = alloc_ports();
 
-    let pc = build_peer().await?;
+    let pc = build_peer(&state).await?;
 
     // Forward the guest's RTP to the FFmpeg UDP ports, rewriting the payload
     // type to our fixed values so the SDP FFmpeg reads is deterministic.
@@ -138,7 +138,7 @@ pub async fn start_guest_ingest(
     Ok(sdp)
 }
 
-async fn build_peer() -> Result<Arc<RTCPeerConnection>, String> {
+async fn build_peer(state: &AppState) -> Result<Arc<RTCPeerConnection>, String> {
     let mut m = MediaEngine::default();
     m.register_codec(
         RTCRtpCodecParameters {
@@ -180,11 +180,19 @@ async fn build_peer() -> Result<Arc<RTCPeerConnection>, String> {
         .with_interceptor_registry(registry)
         .build();
 
-    let config = RTCConfiguration {
-        ice_servers: vec![RTCIceServer {
-            urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+    let ice_servers = crate::routes::webrtc_config::load(state)
+        .await
+        .ice_servers
+        .into_iter()
+        .map(|s| RTCIceServer {
+            urls: s.urls,
+            username: s.username.unwrap_or_default(),
+            credential: s.credential.unwrap_or_default(),
             ..Default::default()
-        }],
+        })
+        .collect();
+    let config = RTCConfiguration {
+        ice_servers,
         ..Default::default()
     };
 

--- a/crates/api/src/routes/guests.rs
+++ b/crates/api/src/routes/guests.rs
@@ -41,6 +41,8 @@ pub struct GuestListItem {
 pub struct GuestInfo {
     pub name: String,
     pub status: String,
+    /// ICE servers (STUN/TURN) the guest browser should use — matches the peer.
+    pub ice_servers: Vec<crate::routes::webrtc_config::IceServer>,
 }
 
 // ── Authenticated (operator) ──────────────────────────────────────────────────
@@ -127,9 +129,12 @@ pub async fn public_info(
     .await?
     .ok_or_else(|| MuxshedError::NotFound("guest link not found".to_string()))?;
 
+    let ice_servers = crate::routes::webrtc_config::load(&state).await.ice_servers;
+
     Ok(Json(GuestInfo {
         name: row.0,
         status: row.1,
+        ice_servers,
     }))
 }
 

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -19,6 +19,7 @@ mod status;
 mod stingers;
 mod stream;
 mod switching;
+pub mod webrtc_config;
 mod ws;
 
 use crate::auth::auth_middleware;
@@ -97,6 +98,10 @@ pub fn build_router(state: Arc<AppState>, web_dir: Option<std::path::PathBuf>) -
         .route("/delay/bleep", post(delay::bleep))
         // Output config and stats
         .route("/output/config", get(output::get_config).put(output::set_config))
+        .route(
+            "/webrtc/config",
+            get(webrtc_config::get_config).put(webrtc_config::set_config),
+        )
         .route("/output/stats", get(output::get_stats))
         // Public channel (HLS broadcast) config
         .route("/channel", get(channel::get_channel).put(channel::update_channel))

--- a/crates/api/src/routes/webrtc_config.rs
+++ b/crates/api/src/routes/webrtc_config.rs
@@ -1,0 +1,72 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! ICE configuration for guest WebRTC. Stored as a `settings` blob and shared by
+//! both the server-side peer (`crate::guest_webrtc`) and the guest browser (via
+//! the public `GET /guest/{token}` response), so the two always agree on which
+//! STUN/TURN servers to use. Off-LAN guests behind strict NAT need a TURN entry
+//! here (see `docs/guests-webrtc.md`).
+
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// A single ICE server, shaped to match the browser `RTCIceServer` dictionary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IceServer {
+    pub urls: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebrtcConfig {
+    pub ice_servers: Vec<IceServer>,
+}
+
+impl Default for WebrtcConfig {
+    fn default() -> Self {
+        Self {
+            ice_servers: vec![IceServer {
+                urls: vec!["stun:stun.l.google.com:19302".to_string()],
+                username: None,
+                credential: None,
+            }],
+        }
+    }
+}
+
+/// Load the configured ICE servers, falling back to the STUN default.
+pub async fn load(state: &AppState) -> WebrtcConfig {
+    sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key = 'webrtc_config'")
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|(json,)| serde_json::from_str(&json).ok())
+        .unwrap_or_default()
+}
+
+pub async fn get_config(State(state): State<Arc<AppState>>) -> Result<Json<WebrtcConfig>, ApiError> {
+    Ok(Json(load(&state).await))
+}
+
+pub async fn set_config(
+    State(state): State<Arc<AppState>>,
+    Json(config): Json<WebrtcConfig>,
+) -> Result<Json<WebrtcConfig>, ApiError> {
+    let json = serde_json::to_string(&config)
+        .map_err(|e| muxshed_common::MuxshedError::Internal(e.to_string()))?;
+
+    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('webrtc_config', ?)")
+        .bind(&json)
+        .execute(&state.db)
+        .await?;
+
+    Ok(Json(config))
+}

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -643,6 +643,9 @@ async fn test_guest_public_info() {
     let info = response_json(resp).await;
     assert_eq!(info["name"], "Sam");
     assert_eq!(info["status"], "invited");
+    // The join page receives ICE servers matching the server peer.
+    assert!(info["ice_servers"].is_array());
+    assert!(!info["ice_servers"].as_array().unwrap().is_empty());
 
     // Unknown token → 404.
     let req = Request::builder()
@@ -679,6 +682,40 @@ async fn test_guest_whip_malformed_offer() {
     // A malformed SDP offer is rejected during negotiation; the ephemeral
     // source is rolled back.
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_webrtc_config_default_and_update() {
+    let (app, key, _s) = setup().await;
+
+    // Default config exposes at least one (STUN) ICE server.
+    let resp = app
+        .clone()
+        .oneshot(json_request("GET", "/api/v1/webrtc/config", &key, None))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let cfg = response_json(resp).await;
+    assert!(!cfg["ice_servers"].as_array().unwrap().is_empty());
+
+    // Add a TURN server and read it back.
+    let body = r#"{"ice_servers":[{"urls":["stun:stun.l.google.com:19302"]},{"urls":["turn:turn.example.com:3478"],"username":"u","credential":"p"}]}"#;
+    let resp = app
+        .clone()
+        .oneshot(json_request("PUT", "/api/v1/webrtc/config", &key, Some(body)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = app
+        .oneshot(json_request("GET", "/api/v1/webrtc/config", &key, None))
+        .await
+        .unwrap();
+    let cfg = response_json(resp).await;
+    let servers = cfg["ice_servers"].as_array().unwrap();
+    assert_eq!(servers.len(), 2);
+    assert_eq!(servers[1]["urls"][0], "turn:turn.example.com:3478");
+    assert_eq!(servers[1]["username"], "u");
 }
 
 #[tokio::test]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@
 # syntax=docker/dockerfile:1.7
 
 # --- cargo-chef: pre-built image (skips 5min cargo-chef compile) ---
-FROM lukemathwalker/cargo-chef:latest-rust-1.87 AS chef
+# Rust 1.88+ required: the webrtc dependency tree (via rcgen -> time) needs it.
+FROM lukemathwalker/cargo-chef:latest-rust-1.88 AS chef
 WORKDIR /build
 
 FROM chef AS planner

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -3,7 +3,8 @@
 # Dev image — no GStreamer, uses stub pipeline controller.
 
 # --- Rust builder ---
-FROM rust:1.87-slim AS rust-builder
+# Rust 1.88+ required by the webrtc dependency tree (via rcgen -> time).
+FROM rust:1.88-slim AS rust-builder
 
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,5 +19,25 @@ services:
       - RUST_LOG=info
     restart: unless-stopped
 
+  # Optional TURN relay for WebRTC guests behind strict NAT.
+  # Enable with:  docker compose --profile turn up
+  # Then set the TURN URL/username/credential under Guests -> Connectivity.
+  # Replace REALM/secret and the external IP for production.
+  coturn:
+    image: coturn/coturn:latest
+    profiles: ["turn"]
+    network_mode: host
+    restart: unless-stopped
+    command: >
+      -n
+      --realm=muxshed
+      --listening-port=3478
+      --fingerprint
+      --lt-cred-mech
+      --user=guest:changeme
+      --no-tls
+      --no-dtls
+      --no-cli
+
 volumes:
   muxshed-data:

--- a/docs/guests-webrtc.md
+++ b/docs/guests-webrtc.md
@@ -37,13 +37,33 @@ Guests join via an unguessable invite link, allow camera/mic in the browser, and
 - Integration tests cover invite/list/delete, public info (+404), and the WHIP contract
   (unknown token → 404, malformed offer → 400 with rollback).
 
+## Connectivity (STUN / TURN)
+
+ICE servers are configurable and stored in `settings` under `webrtc_config`
+(`crates/api/src/routes/webrtc_config.rs`). The **same list is used by the server peer and
+handed to the guest browser** via `GET /guest/{token}` (`ice_servers`), so the two always
+agree. Default: a single public STUN server.
+
+- **API**: `GET`/`PUT /api/v1/webrtc/config` (operator).
+- **UI**: Guests → Connectivity (TURN) — set a TURN URL + username/credential, or leave
+  blank for STUN-only.
+- **TURN relay**: guests behind strict/symmetric NAT need TURN. An optional `coturn` service
+  ships in `docker/docker-compose.yml` under the `turn` profile:
+
+  ```sh
+  docker compose --profile turn up      # starts muxshed + coturn (host networking, :3478)
+  ```
+
+  Then point the Connectivity form at `turn:<host>:3478` with the configured
+  username/credential (change the `guest:changeme` default in the compose file). LAN guests
+  work without TURN.
+
 ## Not yet done
 
-- **TURN** — guests behind strict NAT need a TURN relay. Today only a public STUN server is
-  advertised, so LAN/same-network guests connect but off-LAN guests behind symmetric NAT
-  may not. Next: document/bundle an optional `coturn` and advertise its ICE servers.
 - **Codec breadth** — pinned to VP8 + Opus for a deterministic ffmpeg SDP. H.264 guests
   would need dynamic SDP/PT handling.
+- **TURN REST credentials** — only static long-term credentials are supported; coturn's
+  time-limited (HMAC) credential REST API is not yet wired.
 - ffmpeg in the runtime image must have the **VP8 decoder** (libvpx) and **libx264** — both
   are present in the standard Ubuntu ffmpeg the Docker image installs.
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,6 @@
 // Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
 
-import type { Source, SourceKind, Destination, DestinationKind, ApiKey, Scene, Layer, RecordingState, StingerConfig, StingerAudio, DelayConfig, Guest, BroadcastConfig, OutputConfig, OutputStats, AudioRouting, Asset, AssetFolder, User, ChannelConfig } from './types';
+import type { Source, SourceKind, Destination, DestinationKind, ApiKey, Scene, Layer, RecordingState, StingerConfig, StingerAudio, DelayConfig, Guest, BroadcastConfig, OutputConfig, OutputStats, AudioRouting, Asset, AssetFolder, User, ChannelConfig, WebrtcConfig } from './types';
 
 function getSessionToken(): string {
 	if (typeof window === 'undefined') return '';
@@ -142,6 +142,11 @@ export const api = {
 	setOutputConfig: (config: OutputConfig) =>
 		request<OutputConfig>('/output/config', { method: 'PUT', body: JSON.stringify(config) }),
 	getOutputStats: () => request<OutputStats>('/output/stats'),
+
+	// WebRTC / guest ICE config
+	getWebrtcConfig: () => request<WebrtcConfig>('/webrtc/config'),
+	setWebrtcConfig: (config: WebrtcConfig) =>
+		request<WebrtcConfig>('/webrtc/config', { method: 'PUT', body: JSON.stringify(config) }),
 
 	// Broadcast config
 	getBroadcastConfig: () => request<BroadcastConfig>('/broadcast/config'),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -155,6 +155,16 @@ export interface OutputConfig {
 	fps: number;
 }
 
+export interface IceServer {
+	urls: string[];
+	username?: string;
+	credential?: string;
+}
+
+export interface WebrtcConfig {
+	ice_servers: IceServer[];
+}
+
 export interface OutputStats {
 	bytes_sent: number;
 	duration_secs: number;

--- a/web/src/routes/(app)/guests/+page.svelte
+++ b/web/src/routes/(app)/guests/+page.svelte
@@ -3,20 +3,64 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api';
 	import { notify } from '$lib/notify';
-	import type { Guest } from '$lib/types';
+	import type { Guest, IceServer } from '$lib/types';
 
 	let guests = $state<Guest[]>([]);
 	let name = $state('');
 	let creating = $state(false);
 	let copied = $state<string | null>(null);
 
-	onMount(load);
+	// TURN / connectivity
+	let turnUrl = $state('');
+	let turnUser = $state('');
+	let turnCred = $state('');
+	let savingTurn = $state(false);
+
+	onMount(() => {
+		load();
+		loadTurn();
+	});
 
 	async function load() {
 		try {
 			guests = await api.listGuests();
 		} catch (e) {
 			notify.error(e);
+		}
+	}
+
+	async function loadTurn() {
+		try {
+			const cfg = await api.getWebrtcConfig();
+			const turn = cfg.ice_servers.find((s) => (s.urls[0] ?? '').startsWith('turn'));
+			if (turn) {
+				turnUrl = turn.urls[0] ?? '';
+				turnUser = turn.username ?? '';
+				turnCred = turn.credential ?? '';
+			}
+		} catch (e) {
+			notify.error(e);
+		}
+	}
+
+	async function saveTurn(e: Event) {
+		e.preventDefault();
+		savingTurn = true;
+		try {
+			const ice: IceServer[] = [{ urls: ['stun:stun.l.google.com:19302'] }];
+			if (turnUrl.trim()) {
+				ice.push({
+					urls: [turnUrl.trim()],
+					username: turnUser.trim() || undefined,
+					credential: turnCred.trim() || undefined
+				});
+			}
+			await api.setWebrtcConfig({ ice_servers: ice });
+			notify.success('Connectivity saved');
+		} catch (e) {
+			notify.error(e);
+		} finally {
+			savingTurn = false;
 		}
 	}
 
@@ -97,6 +141,45 @@
 					</div>
 				{/each}
 			{/if}
+		</div>
+	</section>
+
+	<section class="panel">
+		<div class="panel__head">▮ Connectivity (TURN)</div>
+		<div class="panel__body">
+			<p class="mb-3 text-[12px] text-amber-muted">
+				Guests on the same network connect over STUN (always on). Guests behind strict NAT need a
+				TURN relay — point this at your own <span class="text-amber-dim">coturn</span> server. Leave
+				blank to use STUN only.
+			</p>
+			<form onsubmit={saveTurn} class="space-y-3">
+				<div>
+					<label class="field-label" for="turn-url">TURN URL</label>
+					<input
+						id="turn-url"
+						class="input"
+						bind:value={turnUrl}
+						placeholder="turn:turn.example.com:3478"
+					/>
+				</div>
+				<div class="grid gap-3 sm:grid-cols-2">
+					<div>
+						<label class="field-label" for="turn-user">Username</label>
+						<input id="turn-user" class="input" bind:value={turnUser} autocomplete="off" />
+					</div>
+					<div>
+						<label class="field-label" for="turn-cred">Credential</label>
+						<input
+							id="turn-cred"
+							class="input"
+							type="password"
+							bind:value={turnCred}
+							autocomplete="off"
+						/>
+					</div>
+				</div>
+				<button type="submit" disabled={savingTurn} class="btn">Save connectivity</button>
+			</form>
 		</div>
 	</section>
 </div>

--- a/web/src/routes/guest/[token]/+page.svelte
+++ b/web/src/routes/guest/[token]/+page.svelte
@@ -13,6 +13,7 @@
 	let videoEl = $state<HTMLVideoElement | null>(null);
 	let stream: MediaStream | null = null;
 	let pc: RTCPeerConnection | null = null;
+	let iceServers: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
 
 	onMount(async () => {
 		try {
@@ -23,6 +24,9 @@
 			}
 			const info = await res.json();
 			guestName = info.name ?? 'Guest';
+			if (Array.isArray(info.ice_servers) && info.ice_servers.length > 0) {
+				iceServers = info.ice_servers;
+			}
 			await startCamera();
 			mode = 'ready';
 		} catch {
@@ -49,7 +53,7 @@
 		mode = 'joining';
 		message = '';
 		try {
-			pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
+			pc = new RTCPeerConnection({ iceServers });
 			stream.getTracks().forEach((t) => pc!.addTrack(t, stream!));
 
 			const offer = await pc.createOffer();


### PR DESCRIPTION
Follows up #1 (already merged). Two commits that landed after that merge:

## Unblocks the Docker build (merge this)
#1 merged the `webrtc` dependency, which requires rustc 1.88 (via rcgen -> time 0.3.51), but the Docker builders were still pinned to 1.87 — so `main` currently fails to build the image (`time@0.3.51 requires rustc 1.88.0`). `fix(docker)` bumps both `docker/Dockerfile` (cargo-chef `latest-rust-1.88`, tag verified to exist) and `docker/Dockerfile.dev` (`rust:1.88-slim`).

## Configurable STUN/TURN + optional coturn
- `routes/webrtc_config.rs`: `GET`/`PUT /api/v1/webrtc/config` (settings blob, default = public STUN)
- the server peer and the guest browser share the same ICE list (returned in `GET /guest/{token}`), so they can't drift
- Guests admin page: Connectivity (TURN) form
- optional `coturn` service in `docker-compose.yml` under the `turn` profile
- `docs/guests-webrtc.md`: STUN/TURN section

## Verified
`cargo test` 22 passed; `cargo clippy --workspace -D warnings` clean; `svelte-check` 0/0. Live WebRTC media still needs a real-browser test (can't run headless).