### PR TITLE
Release v1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-api"
-version = "1.1.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-common"
-version = "1.1.1"
+version = "1.4.2"
 dependencies = [
  "chrono",
  "serde",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-processor"
-version = "1.1.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.1"
+version = "1.4.2"
 rust-version = "1.88"
 
 [workspace.dependencies]


### PR DESCRIPTION
Cuts everything merged since v1.1.1 into a tagged release (bumps the workspace version to 1.4.2).

## Included since 1.1.1
- **WebRTC guest video fix** — receiver-pump so both bundled tracks ingest; PLI keyframes + ffmpeg analyzeduration; ICE-gathering, port-probe, watchdog
- **Removed broadcast delay + bleep** (non-functional stub)
- **OBS-style scene compositor** — per-frame layered program output (position/size/z-order/opacity)
- **Browser sources** — render any web page as a live source (headless Chrome → CDP → ffmpeg)
- **Configurable STUN/TURN** + optional coturn for guests
- **Test suite** — 40 tests (common serialization, compositor logic, REST endpoints); clippy --all-targets clean
- Watch-page liveness/restart recovery; migration self-heal on upgrade