### PR TITLE
Release v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-api"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-common"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "serde",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-processor"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.2"
+version = "1.5.0"
 rust-version = "1.88"
 
 [workspace.dependencies]


### PR DESCRIPTION
Supersedes **v1.4.2**, which shipped with the compositor bugs fixed below. Bumps the workspace version to 1.5.0.

## Since v1.4.2
### Scene compositor (fixes)
- **Multi-layer scenes rendered nothing** — bounded ffmpeg input probing so a low-bitrate layer (e.g. a still image) opens promptly instead of stalling the whole graph
- **One dead source black-out the program** — layers are only composited if their source is actually producing video; dead layers (e.g. a browser source that never rendered) are skipped
- **Timestamp epochs** rebased per layer (`setpts=PTS-STARTPTS`) so independent sources align

### Features
- **Scene selection in the studio** — a Scenes tab to take a scene to Program
- **Visual scene maker** — drag/resize layers on a 16:9 canvas, z-order, opacity
- **Images in scenes** — media-library assets as layers
- **Per-layer fit modes** — fill / contain / cover (CSS object-fit), with a Fit dropdown in the editor (migration 008)

All verified end-to-end against a running server. 43 tests; clippy --all-targets clean.