### PR TITLE
Program failover: keep the broadcast alive when the source drops

### DIFF
--- a/crates/api/src/failover.rs
+++ b/crates/api/src/failover.rs
@@ -1,0 +1,203 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! Program failover supervisor.
+//!
+//! Sits between the operator's program selection (`program_intent`) and the
+//! source the program router actually forwards (`program_source`). While the
+//! intended source produces video it mirrors intent -> source. When the intended
+//! source stops producing video for `offline_grace_ms` it substitutes the
+//! configured fallback source so destinations keep receiving a stream, then
+//! restores the intended source once it has been producing video again for
+//! `recovery_grace_ms`.
+
+use crate::state::AppState;
+use bytes::Bytes;
+use muxshed_common::{FailoverConfig, SourceKind, WsEvent};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{broadcast, watch};
+use uuid::Uuid;
+
+const FLV_TAG_VIDEO: u8 = 9;
+
+fn is_video_tag(data: &[u8]) -> bool {
+    !data.is_empty() && data[0] == FLV_TAG_VIDEO
+}
+
+/// Load the persisted failover config (defaults = disabled).
+pub async fn load_config(state: &AppState) -> FailoverConfig {
+    sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key = 'failover_config'")
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|(json,)| serde_json::from_str(&json).ok())
+        .unwrap_or_default()
+}
+
+fn route(state: &AppState, source: Option<Uuid>) {
+    let _ = state.program_source.send(source);
+}
+
+pub async fn run_failover_supervisor(state: Arc<AppState>) {
+    let mut intent_rx = state.program_intent.subscribe();
+    loop {
+        let intent = *intent_rx.borrow_and_update();
+        let cfg = load_config(&state).await;
+        let fallback = cfg.fallback_source_id;
+
+        // Passthrough: failover off, no fallback, nothing selected, or the
+        // fallback IS the selection. Just mirror intent -> routed source.
+        if !cfg.enabled || fallback.is_none() || intent.is_none() || fallback == intent {
+            set_failover(&state, false, fallback, intent).await;
+            route(&state, intent);
+            if intent_rx.changed().await.is_err() {
+                return;
+            }
+            continue;
+        }
+
+        let intended = intent.unwrap();
+        let fallback = fallback.unwrap();
+        ensure_fallback_running(&state, fallback).await;
+
+        // Monitor until the operator changes intent (or a config change nudges
+        // program_intent), then re-evaluate from the top.
+        monitor(&state, &mut intent_rx, intended, fallback, &cfg).await;
+    }
+}
+
+async fn monitor(
+    state: &Arc<AppState>,
+    intent_rx: &mut watch::Receiver<Option<Uuid>>,
+    intended: Uuid,
+    fallback: Uuid,
+    cfg: &FailoverConfig,
+) {
+    let offline = Duration::from_millis(cfg.offline_grace_ms.max(250));
+    let recovery = Duration::from_millis(cfg.recovery_grace_ms.max(250));
+
+    let mut rx: Option<broadcast::Receiver<Bytes>> =
+        state.get_media_relay(&intended).await.map(|t| t.subscribe());
+    let mut last_video = Instant::now();
+    let mut recovering_since: Option<Instant> = None;
+    let mut showing_fallback = false;
+    // Whether the intended source has ever produced a video frame. Before its
+    // first frame it may just be warming up (an RTMP source's normalizer takes a
+    // second or two), so give it a longer startup grace rather than failing over
+    // on a source that simply hasn't started yet.
+    let mut ever_live = false;
+    let startup_grace = offline.max(Duration::from_secs(5));
+
+    route(state, Some(intended));
+    set_failover(state, false, Some(fallback), Some(intended)).await;
+
+    let mut ticker = tokio::time::interval(Duration::from_millis(250));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            // Operator switched (or a config change nudged intent) — bail to re-evaluate.
+            r = intent_rx.changed() => {
+                let _ = r;
+                return;
+            }
+            // Frames from the intended source.
+            msg = async {
+                match &mut rx {
+                    Some(r) => r.recv().await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                match msg {
+                    Ok(data) => {
+                        if is_video_tag(&data) {
+                            last_video = Instant::now();
+                            ever_live = true;
+                            if showing_fallback {
+                                recovering_since.get_or_insert_with(Instant::now);
+                            }
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Closed) => rx = None,
+                }
+            }
+            _ = ticker.tick() => {
+                let now = Instant::now();
+                // Re-subscribe if the source reconnected (a fresh relay).
+                if rx.is_none() {
+                    if let Some(t) = state.get_media_relay(&intended).await {
+                        rx = Some(t.subscribe());
+                    }
+                }
+                let dark_for = now.duration_since(last_video);
+                let threshold = if ever_live { offline } else { startup_grace };
+
+                if !showing_fallback && dark_for > threshold {
+                    tracing::warn!(
+                        "failover: program source {} offline ({}ms) -> fallback {}",
+                        intended, dark_for.as_millis(), fallback
+                    );
+                    ensure_fallback_running(state, fallback).await;
+                    route(state, Some(fallback));
+                    showing_fallback = true;
+                    recovering_since = None;
+                    set_failover(state, true, Some(fallback), Some(intended)).await;
+                } else if showing_fallback {
+                    if dark_for > Duration::from_millis(750) {
+                        // Intended went dark again before recovery confirmed.
+                        recovering_since = None;
+                    } else if let Some(since) = recovering_since {
+                        if now.duration_since(since) > recovery {
+                            tracing::info!("failover: program source {} recovered -> restoring", intended);
+                            route(state, Some(intended));
+                            showing_fallback = false;
+                            recovering_since = None;
+                            set_failover(state, false, Some(fallback), Some(intended)).await;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn set_failover(state: &AppState, active: bool, fallback: Option<Uuid>, intent: Option<Uuid>) {
+    let changed = *state.failover_active.borrow() != active;
+    let _ = state.failover_active.send(active);
+    if changed {
+        let _ = state.ws_tx.send(WsEvent::FailoverState {
+            active,
+            fallback_source_id: fallback,
+            intent_source_id: intent,
+        });
+    }
+}
+
+/// Pre-start an image/video fallback so its relay has frames the instant we cut.
+/// A live-ingress fallback already has a relay when its encoder connects.
+async fn ensure_fallback_running(state: &Arc<AppState>, fallback: Uuid) {
+    if state.get_media_relay(&fallback).await.is_some() {
+        return;
+    }
+    let row = sqlx::query_as::<_, (String,)>("SELECT kind FROM sources WHERE id = ?")
+        .bind(fallback.to_string())
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten();
+    if let Some((kind_json,)) = row {
+        if let Ok(SourceKind::MediaFile { file_path, loop_mode, .. }) =
+            serde_json::from_str::<SourceKind>(&kind_json)
+        {
+            let _ = crate::media_player::start_media_playback(
+                state.clone(),
+                fallback,
+                &file_path,
+                &loop_mode,
+            )
+            .await;
+        }
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod auth;
 pub mod channel_hls;
 pub mod egress;
+pub mod failover;
 pub mod guest_webrtc;
 pub mod media_player;
 pub mod media_probe;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -81,6 +81,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (ws_tx, _) = broadcast::channel::<WsEvent>(256);
     let (program_tx, _) = broadcast::channel::<bytes::Bytes>(4096);
     let (program_source_tx, _program_source_rx) = watch::channel::<Option<uuid::Uuid>>(None);
+    let (program_intent_tx, _program_intent_rx) = watch::channel::<Option<uuid::Uuid>>(None);
+    let (failover_active_tx, _failover_active_rx) = watch::channel::<bool>(false);
     let saved_audio_routing: muxshed_api::state::AudioRouting = sqlx::query_as::<_, (String,)>(
         "SELECT value FROM settings WHERE key = 'audio_routing'",
     )
@@ -117,6 +119,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         browser_sources: RwLock::new(std::collections::HashMap::new()),
         program_tx,
         program_source: program_source_tx,
+        program_intent: program_intent_tx,
+        failover_active: failover_active_tx,
         preview_source: RwLock::new(None),
         audio_routing: audio_routing_tx,
         system_token,
@@ -174,6 +178,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let program_state = state.clone();
     tokio::spawn(async move {
         run_program_router(program_state).await;
+    });
+
+    // Failover supervisor: mirrors the operator's program intent to the routed
+    // program source, substituting the configured fallback when the program
+    // goes offline and restoring it on recovery.
+    let failover_state = state.clone();
+    tokio::spawn(async move {
+        muxshed_api::failover::run_failover_supervisor(failover_state).await;
     });
 
     let rtmp_state = state.clone();

--- a/crates/api/src/routes/failover.rs
+++ b/crates/api/src/routes/failover.rs
@@ -1,0 +1,30 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+use axum::extract::State;
+use axum::Json;
+use std::sync::Arc;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+use muxshed_common::{FailoverConfig, MuxshedError};
+
+pub async fn get_config(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<FailoverConfig>, ApiError> {
+    Ok(Json(crate::failover::load_config(&state).await))
+}
+
+pub async fn set_config(
+    State(state): State<Arc<AppState>>,
+    Json(cfg): Json<FailoverConfig>,
+) -> Result<Json<FailoverConfig>, ApiError> {
+    let json = serde_json::to_string(&cfg).map_err(|e| MuxshedError::Internal(e.to_string()))?;
+    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('failover_config', ?)")
+        .bind(&json)
+        .execute(&state.db)
+        .await?;
+    // Nudge the supervisor to re-read config immediately.
+    let current = *state.program_intent.borrow();
+    let _ = state.program_intent.send(current);
+    Ok(Json(cfg))
+}

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -3,6 +3,7 @@
 mod assets;
 mod audio;
 mod auth;
+mod failover;
 mod broadcast;
 mod channel;
 mod preview;
@@ -92,6 +93,7 @@ pub fn build_router(state: Arc<AppState>, web_dir: Option<std::path::PathBuf>) -
         .route("/destinations/{id}/disable", post(destinations::disable))
         // Output config and stats
         .route("/output/config", get(output::get_config).put(output::set_config))
+        .route("/failover", get(failover::get_config).put(failover::set_config))
         .route(
             "/webrtc/config",
             get(webrtc_config::get_config).put(webrtc_config::set_config),

--- a/crates/api/src/routes/scenes.rs
+++ b/crates/api/src/routes/scenes.rs
@@ -174,7 +174,7 @@ pub async fn activate(
     crate::scene_compositor::start_scene_compositor(state.clone(), scene_uuid)
         .await
         .map_err(|e| MuxshedError::BadRequest(format!("cannot activate scene: {}", e)))?;
-    let _ = state.program_source.send(Some(scene_uuid));
+    let _ = state.program_intent.send(Some(scene_uuid));
     state.pipeline.activate_scene(&scene_uuid).await?;
 
     let _ = state.ws_tx.send(WsEvent::SceneChanged {
@@ -189,7 +189,7 @@ pub async fn activate(
 /// to its layers take effect immediately).
 async fn refresh_if_active(state: &Arc<AppState>, scene_id: &str) {
     if let Ok(uuid) = scene_id.parse::<Uuid>() {
-        if *state.program_source.borrow() == Some(uuid) {
+        if *state.program_intent.borrow() == Some(uuid) {
             let _ = crate::scene_compositor::start_scene_compositor(state.clone(), uuid).await;
         }
     }

--- a/crates/api/src/routes/stream.rs
+++ b/crates/api/src/routes/stream.rs
@@ -124,7 +124,7 @@ pub async fn start(
     }
 
     // THEN set program source — program router wakes up and starts forwarding
-    let _ = state.program_source.send(Some(source_id));
+    let _ = state.program_intent.send(Some(source_id));
     tracing::info!("program source set to {}", source_id);
 
     if saved_config.auto_record {
@@ -157,7 +157,7 @@ pub async fn stop(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiE
 
     state.egress.stop().await;
     state.channel_hls.stop().await;
-    let _ = state.program_source.send(None);
+    let _ = state.program_intent.send(None);
     let _ = state.pipeline.stop_recording().await;
     state.pipeline.stop().await?;
 

--- a/crates/api/src/routes/switching.rs
+++ b/crates/api/src/routes/switching.rs
@@ -13,18 +13,26 @@ use muxshed_common::{MuxshedError, WsEvent};
 
 #[derive(Serialize)]
 pub struct ProgramState {
+    /// The source actually being broadcast (the fallback during a failover).
     pub program_source_id: Option<Uuid>,
+    /// The operator-selected source (what they intend on program).
+    pub program_intent_id: Option<Uuid>,
     pub preview_source_id: Option<Uuid>,
+    /// True when the program is on the fallback because the intended source is offline.
+    pub failover_active: bool,
 }
 
 pub async fn get_program(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<ProgramState>, ApiError> {
     let program = *state.program_source.borrow();
+    let intent = *state.program_intent.borrow();
     let preview = *state.preview_source.read().await;
     Ok(Json(ProgramState {
         program_source_id: program,
+        program_intent_id: intent,
         preview_source_id: preview,
+        failover_active: *state.failover_active.borrow(),
     }))
 }
 
@@ -66,7 +74,7 @@ pub async fn cut(
 
     // Cutting to a single source replaces any active scene composite.
     crate::scene_compositor::stop_all_compositors(&state).await;
-    let _ = state.program_source.send(Some(id));
+    let _ = state.program_intent.send(Some(id));
 
     let _ = state.ws_tx.send(WsEvent::SceneChanged {
         scene_id: id,
@@ -84,7 +92,7 @@ pub async fn auto(
     let preview_id = preview
         .ok_or_else(|| MuxshedError::BadRequest("no source in preview".to_string()))?;
 
-    let _ = state.program_source.send(Some(preview_id));
+    let _ = state.program_intent.send(Some(preview_id));
 
     // Clear preview
     let mut p = state.preview_source.write().await;

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -35,8 +35,15 @@ pub struct AppState {
     pub channel_hls: ChannelHls,
     /// Program output — the channel that egress and preview-program read from
     pub program_tx: broadcast::Sender<Bytes>,
-    /// Which source provides video to program
+    /// The source actually routed to program. Written by the failover supervisor,
+    /// read by the program router. During a failover this is the fallback source.
     pub program_source: watch::Sender<Option<Uuid>>,
+    /// The operator's selected program source. The failover supervisor mirrors
+    /// this to `program_source` when it is live, or substitutes the fallback when
+    /// it goes offline. All operator-facing switches set this, not program_source.
+    pub program_intent: watch::Sender<Option<Uuid>>,
+    /// Whether a failover is currently engaged (program is on the fallback).
+    pub failover_active: watch::Sender<bool>,
     /// Which source is in preview (next to go live)
     pub preview_source: RwLock<Option<Uuid>>,
     /// Audio routing: which sources are providing audio and at what level

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -22,6 +22,8 @@ async fn setup() -> (axum::Router<()>, String, Arc<AppState>) {
     let (ws_tx, _) = broadcast::channel::<WsEvent>(64);
     let (program_tx, _) = broadcast::channel::<bytes::Bytes>(64);
     let (program_source_tx, _) = tokio::sync::watch::channel::<Option<uuid::Uuid>>(None);
+    let (program_intent_tx, _) = tokio::sync::watch::channel::<Option<uuid::Uuid>>(None);
+    let (failover_active_tx, _) = tokio::sync::watch::channel::<bool>(false);
     let (audio_routing_tx, _) = tokio::sync::watch::channel(muxshed_api::state::AudioRouting::default());
     let pipeline = Arc::new(StubPipelineController::new(ws_tx.clone()));
 
@@ -66,6 +68,8 @@ async fn setup() -> (axum::Router<()>, String, Arc<AppState>) {
         browser_sources: tokio::sync::RwLock::new(std::collections::HashMap::new()),
         program_tx,
         program_source: program_source_tx,
+        program_intent: program_intent_tx,
+        failover_active: failover_active_tx,
         preview_source: tokio::sync::RwLock::new(None),
         audio_routing: audio_routing_tx,
         system_token: None,

--- a/crates/common/src/events.rs
+++ b/crates/common/src/events.rs
@@ -35,6 +35,13 @@ pub enum WsEvent {
     TransitionComplete {
         scene_id: Uuid,
     },
+    /// Program failover engaged or cleared (main source offline -> fallback).
+    FailoverState {
+        active: bool,
+        fallback_source_id: Option<Uuid>,
+        /// The operator-selected source the failover is standing in for.
+        intent_source_id: Option<Uuid>,
+    },
     Error {
         message: String,
         code: String,

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -183,6 +183,32 @@ pub struct RecordingState {
     pub started_at: Option<DateTime<Utc>>,
 }
 
+/// Program failover: when the live program output stops producing video, the
+/// program is automatically switched to a fallback source (a BRB image/video or
+/// a backup ingress) so destinations don't drop, then switched back on recovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailoverConfig {
+    pub enabled: bool,
+    /// Source shown while the program is offline. Any source: an image/video
+    /// asset (a "be right back" card) or a backup live ingress.
+    pub fallback_source_id: Option<Uuid>,
+    /// How long the program must produce no video before failing over.
+    pub offline_grace_ms: u64,
+    /// How long the program must be producing video again before switching back.
+    pub recovery_grace_ms: u64,
+}
+
+impl Default for FailoverConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            fallback_source_id: None,
+            offline_grace_ms: 3000,
+            recovery_grace_ms: 3000,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelConfig {
     pub enabled: bool,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,6 @@
 // Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
 
-import type { Source, SourceKind, Destination, DestinationKind, ApiKey, Scene, Layer, LayerFit, RecordingState, StingerConfig, StingerAudio, Guest, BroadcastConfig, OutputConfig, OutputStats, AudioRouting, Asset, AssetFolder, User, ChannelConfig, WebrtcConfig } from './types';
+import type { Source, SourceKind, Destination, DestinationKind, ApiKey, Scene, Layer, LayerFit, RecordingState, StingerConfig, StingerAudio, Guest, BroadcastConfig, OutputConfig, OutputStats, AudioRouting, Asset, AssetFolder, User, ChannelConfig, WebrtcConfig, FailoverConfig } from './types';
 
 function getSessionToken(): string {
 	if (typeof window === 'undefined') return '';
@@ -141,6 +141,10 @@ export const api = {
 	getOutputConfig: () => request<OutputConfig>('/output/config'),
 	setOutputConfig: (config: OutputConfig) =>
 		request<OutputConfig>('/output/config', { method: 'PUT', body: JSON.stringify(config) }),
+
+	getFailover: () => request<FailoverConfig>('/failover'),
+	setFailover: (config: FailoverConfig) =>
+		request<FailoverConfig>('/failover', { method: 'PUT', body: JSON.stringify(config) }),
 	getOutputStats: () => request<OutputStats>('/output/stats'),
 
 	// WebRTC / guest ICE config

--- a/web/src/lib/stores/pipeline.ts
+++ b/web/src/lib/stores/pipeline.ts
@@ -8,6 +8,11 @@ export const sources = writable<Source[]>([]);
 export const destinations = writable<Destination[]>([]);
 export const scenes = writable<Scene[]>([]);
 export const recordingState = writable<RecordingState>({ recording: false });
+export const failover = writable<{
+	active: boolean;
+	fallback_source_id: string | null;
+	intent_source_id: string | null;
+}>({ active: false, fallback_source_id: null, intent_source_id: null });
 
 export const isLive = derived(pipelineState, ($s) => $s.state === 'live');
 export const isTransitioning = derived(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -157,6 +157,13 @@ export interface OutputConfig {
 	fps: number;
 }
 
+export interface FailoverConfig {
+	enabled: boolean;
+	fallback_source_id: string | null;
+	offline_grace_ms: number;
+	recovery_grace_ms: number;
+}
+
 export interface IceServer {
 	urls: string[];
 	username?: string;
@@ -229,4 +236,8 @@ export type WsEvent =
 	| { type: 'recording_state'; payload: { recording: boolean; path?: string } }
 	| { type: 'transition_started'; payload: { stinger_id: string; target_scene_id: string } }
 	| { type: 'transition_complete'; payload: { scene_id: string } }
+	| {
+			type: 'failover_state';
+			payload: { active: boolean; fallback_source_id: string | null; intent_source_id: string | null };
+	  }
 	| { type: 'error'; payload: { message: string; code: string } };

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,6 +1,6 @@
 // Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
 
-import { pipelineState, sources, destinations, recordingState } from './stores/pipeline';
+import { pipelineState, sources, destinations, recordingState, failover } from './stores/pipeline';
 import type { WsEvent } from './types';
 
 let ws: WebSocket | null = null;
@@ -85,6 +85,13 @@ function handleEvent(event: WsEvent) {
 			recordingState.set({
 				recording: event.payload.recording,
 				path: event.payload.path,
+			});
+			break;
+		case 'failover_state':
+			failover.set({
+				active: event.payload.active,
+				fallback_source_id: event.payload.fallback_source_id,
+				intent_source_id: event.payload.intent_source_id,
 			});
 			break;
 	}

--- a/web/src/routes/(app)/+page.svelte
+++ b/web/src/routes/(app)/+page.svelte
@@ -10,6 +10,7 @@
 		isLive,
 		isRecording,
 		recordingState,
+		failover,
 	} from '$lib/stores/pipeline';
 	import type { StingerConfig, BroadcastConfig, OutputConfig, OutputStats, AudioRouting, Asset } from '$lib/types';
 	import StatusIndicator from '../../components/StatusIndicator.svelte';
@@ -259,6 +260,15 @@
 </script>
 
 <div class="mx-auto max-w-[1400px]">
+	{#if $failover.active}
+		{@const fbName = $sources.find((s) => s.id === $failover.fallback_source_id)?.name ?? 'fallback'}
+		{@const mainName = $sources.find((s) => s.id === $failover.intent_source_id)?.name ?? 'your source'}
+		<div class="mb-3 flex items-center gap-3 rounded border border-warning bg-warning/10 px-4 py-2 text-warning" role="status">
+			<span class="led text-[16px] animate-pulse">⚠ FAILOVER ACTIVE</span>
+			<span class="text-xs">{mainName} is offline — broadcasting <strong>{fbName}</strong>. Will switch back automatically when it returns.</span>
+		</div>
+	{/if}
+
 	<!-- Header -->
 	<div class="mb-4 flex items-center justify-between border-b border-border pb-3">
 		<h1 class="text-[13px] tracking-widest text-amber-bright">STUDIO</h1>

--- a/web/src/routes/(app)/settings/+page.svelte
+++ b/web/src/routes/(app)/settings/+page.svelte
@@ -3,7 +3,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api';
 	import { notify } from '$lib/notify';
-	import type { User } from '$lib/types';
+	import type { User, Source, FailoverConfig } from '$lib/types';
 
 	// Password change
 	let currentPassword = $state('');
@@ -24,10 +24,41 @@
 	// Screen effects
 	let fxOff = $state(false);
 
+	// Program failover
+	let failover = $state<FailoverConfig>({
+		enabled: false,
+		fallback_source_id: null,
+		offline_grace_ms: 3000,
+		recovery_grace_ms: 3000,
+	});
+	let sources = $state<Source[]>([]);
+	let failoverSaving = $state(false);
+
 	onMount(async () => {
 		fxOff = localStorage.getItem('muxshed-fx') === 'off';
 		await refreshUsers();
+		try {
+			[failover, sources] = await Promise.all([api.getFailover(), api.listSources()]);
+		} catch (e) {
+			notify.error(e);
+		}
 	});
+
+	async function saveFailover() {
+		failoverSaving = true;
+		try {
+			failover = await api.setFailover({
+				...failover,
+				offline_grace_ms: Math.max(500, Math.round(failover.offline_grace_ms)),
+				recovery_grace_ms: Math.max(500, Math.round(failover.recovery_grace_ms)),
+			});
+			notify.success('Failover settings saved');
+		} catch (e) {
+			notify.error(e);
+		} finally {
+			failoverSaving = false;
+		}
+	}
 
 	function toggleFx() {
 		fxOff = !fxOff;
@@ -238,6 +269,56 @@
 				<p><span class="text-amber">Write</span> — Stream control: go live, switch sources, manage destinations</p>
 				<p><span class="text-amber">Read</span> — View only: monitor studio, see stats</p>
 			</div>
+		</div>
+	</section>
+
+	<!-- Program failover -->
+	<section class="panel">
+		<header class="panel__head">▮ Program Failover</header>
+		<div class="panel__body">
+			<p class="mb-3 text-xs text-amber-dim leading-relaxed">
+				If the live program output goes offline (e.g. an IRL stream drops), automatically
+				switch to a fallback source so your destinations don't disconnect — then switch back
+				when the main source returns.
+			</p>
+			<div class="row mb-3">
+				<div>
+					<span class="text-amber">Enable failover</span>
+					<p class="text-xs text-amber-dim">Auto-switch to the fallback when program goes dark.</p>
+				</div>
+				<button
+					onclick={() => { failover.enabled = !failover.enabled; saveFailover(); }}
+					class="btn {failover.enabled ? 'btn--go' : ''}"
+				>
+					{failover.enabled ? '● On' : '○ Off'}
+				</button>
+			</div>
+
+			<label class="field-label" for="fo-src">Fallback source</label>
+			<select id="fo-src" bind:value={failover.fallback_source_id} class="select mb-3 w-full">
+				<option value={null}>— Select a source —</option>
+				{#each sources as s}
+					<option value={s.id}>{s.name}</option>
+				{/each}
+			</select>
+			<p class="mb-3 text-[11px] text-amber-muted">
+				A "be right back" image/video (upload it in the Library, add it as a source) or a backup
+				live ingress.
+			</p>
+
+			<div class="grid grid-cols-2 gap-3">
+				<div>
+					<label class="field-label" for="fo-off">Offline after (ms)</label>
+					<input id="fo-off" type="number" min="500" step="500" bind:value={failover.offline_grace_ms} class="input" />
+				</div>
+				<div>
+					<label class="field-label" for="fo-rec">Recover after (ms)</label>
+					<input id="fo-rec" type="number" min="500" step="500" bind:value={failover.recovery_grace_ms} class="input" />
+				</div>
+			</div>
+			<button onclick={saveFailover} disabled={failoverSaving} class="btn btn--go mt-3">
+				{failoverSaving ? 'Saving…' : 'Save failover settings'}
+			</button>
 		</div>
 	</section>
 


### PR DESCRIPTION
## Problem
If the program source goes offline (an IRL stream dropping, the encoder losing the server), the program router has nothing to forward, the program output goes silent, and destinations (YouTube/Twitch) disconnect. The whole broadcast goes down.

## Solution
Program-level failover. A **failover supervisor** sits between the operator's program selection and the source the router actually forwards:

- `program_intent` — what the operator selected (cut/scene-activate/stream-start now set this)
- `program_source` — what the router forwards (the supervisor owns it)

While the intended source produces video, the supervisor mirrors intent → source. When it stops producing video for **`offline_grace_ms`**, it switches the program to a configured **fallback source** — any source: a "be right back" image/video, or a backup live ingress — so destinations keep receiving a stream. When the main returns and produces video for **`recovery_grace_ms`**, it switches back automatically. A startup grace avoids failing over a source that simply hasn't warmed up yet (an RTMP normalizer takes a second or two).

Frame-flow based, so it catches both disconnects and freezes, and works for a single source or a full scene.

## Scope (confirmed with the user)
- **Program-level**, one global fallback
- **Auto switch-back** on recovery

## What's included
- `FailoverConfig` + `FailoverState` WS event (common)
- Supervisor (`failover.rs`) + `GET/PUT /api/v1/failover`; `/program` status now returns `program_intent_id` + `failover_active`
- Settings UI (enable / fallback source / grace) + an on-air failover banner in the studio

## Verified
- Real RTMP source + image fallback: killed → fails over to BRB after the grace, restored → recovers automatically; `program_source` routes main → fallback → main and `failover_active` flips correctly
- Config saved through the browser settings UI (DB reflects it)
- 43 tests pass; `clippy --all-targets` clean; `svelte-check` 0 errors

## Note
No DB migration — config lives in the `settings` table (like output/audio config). Storage is dependency-free per the self-host model.