### PR TITLE
Program failover (complete) + release v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-api"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-common"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "serde",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-processor"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0"
+version = "1.6.0"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/crates/api/src/egress.rs
+++ b/crates/api/src/egress.rs
@@ -13,11 +13,20 @@ use uuid::Uuid;
 use crate::routes::output::OutputStats;
 use crate::rtmp::flv;
 
+type RestartParams = (
+    Vec<Destination>,
+    broadcast::Sender<Bytes>,
+    Option<crate::routes::output::OutputConfig>,
+);
+
 pub struct EgressManager {
     processes: Arc<Mutex<HashMap<Uuid, EgressProcess>>>,
     ws_tx: broadcast::Sender<WsEvent>,
     bytes_sent: Arc<std::sync::atomic::AtomicU64>,
     started_at: Arc<Mutex<Option<std::time::Instant>>>,
+    /// The most recent start() params, so the egress can be cleanly restarted
+    /// (e.g. on a program failover splice) with a fresh encoder.
+    restart_params: Arc<Mutex<Option<RestartParams>>>,
 }
 
 struct EgressProcess {
@@ -32,7 +41,27 @@ impl EgressManager {
             ws_tx,
             bytes_sent: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             started_at: Arc::new(Mutex::new(None)),
+            restart_params: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Restart the egress with the params from the last start(), priming with the
+    /// given source's sequence headers. Used when the program splices to a new
+    /// source (failover) — a fresh encoder produces a clean stream and reconnects
+    /// the destination, instead of the running encoder choking on the splice.
+    pub async fn restart(&self, seq_headers: Option<crate::state::SequenceHeaders>) {
+        let params = self.restart_params.lock().await.clone();
+        let Some((destinations, media_tx, output_config)) = params else {
+            return;
+        };
+        tracing::info!("restarting egress with a fresh encoder (program splice)");
+        self.stop().await;
+        // Let the old RTMP session fully close before reopening the same stream
+        // key (some platforms reject a second publisher on an already-open key).
+        tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+        let _ = self
+            .start(Uuid::nil(), destinations, media_tx, output_config, seq_headers)
+            .await;
     }
 
     pub async fn start(
@@ -45,6 +74,8 @@ impl EgressManager {
     ) -> Result<(), String> {
         self.bytes_sent.store(0, std::sync::atomic::Ordering::Relaxed);
         *self.started_at.lock().await = Some(std::time::Instant::now());
+        *self.restart_params.lock().await =
+            Some((destinations.clone(), media_tx.clone(), output_config.clone()));
         let mut procs = self.processes.lock().await;
 
         for dest in &destinations {
@@ -158,6 +189,12 @@ impl EgressManager {
                     if let Some(ref audio) = seq.audio {
                         let _ = stdin.write_all(audio).await;
                         bytes_written += audio.len() as u64;
+                    }
+                    // Prime with the last keyframe so a freshly (re)started encoder
+                    // can decode immediately instead of waiting for the next one.
+                    if let Some(ref keyframe) = seq.last_keyframe {
+                        let _ = stdin.write_all(keyframe).await;
+                        bytes_written += keyframe.len() as u64;
                     }
                 }
 

--- a/crates/api/src/failover.rs
+++ b/crates/api/src/failover.rs
@@ -141,6 +141,7 @@ async fn monitor(
                     );
                     ensure_fallback_running(state, fallback).await;
                     route(state, Some(fallback));
+                    restart_egress(state, fallback).await;
                     showing_fallback = true;
                     recovering_since = None;
                     set_failover(state, true, Some(fallback), Some(intended)).await;
@@ -152,6 +153,7 @@ async fn monitor(
                         if now.duration_since(since) > recovery {
                             tracing::info!("failover: program source {} recovered -> restoring", intended);
                             route(state, Some(intended));
+                            restart_egress(state, intended).await;
                             showing_fallback = false;
                             recovering_since = None;
                             set_failover(state, false, Some(fallback), Some(intended)).await;
@@ -160,6 +162,16 @@ async fn monitor(
                 }
             }
         }
+    }
+}
+
+/// When live, restart the egress with a fresh encoder so the destination gets a
+/// clean stream across the program splice (a single long-running encoder chokes
+/// on a mid-stream source change). No-op in studio mode (egress not running).
+async fn restart_egress(state: &AppState, source: Uuid) {
+    if state.egress.is_running().await {
+        let seq = state.sequence_headers.read().await.get(&source).cloned();
+        state.egress.restart(seq).await;
     }
 }
 


### PR DESCRIPTION
Closes #5.

Completes program failover so the broadcast **actually stays alive** when the source drops, and bumps the version to **1.6.0**.

## Background
PR #7 added the failover supervisor (routing the program to a fallback when the source goes offline, and back on recovery). Testing the real destination output revealed the routing was correct but the **broadcast still dropped**: a single long-running egress encoder chokes on a mid-stream source splice — the spliced-in fallback frames arrive with a frozen timestamp and the RTMP muxer breaks. The fallback never reached the destination.

## Fix (this PR)
Restart the egress with a **fresh encoder** when the program splices to/from the fallback. A fresh encoder reads the now-clean fallback stream and reconnects the destination (which YouTube/Twitch accept), after a short settle so the old RTMP session closes first. Fresh encoders are primed with the cached keyframe to decode immediately.

## Verified end-to-end 
Against a **persistent RTMP server** (node-media-server, survives reconnects, like a real destination):
- Go live on the main source → destination receives it (session 1).
- Kill the source → supervisor fails over → egress restarts and **reconnects** → the destination receives the **BRB fallback** as a clean session 2 (confirmed by extracting the orange fallback frame from the recorded destination stream).
- Recovery uses the same restart path; the supervisor logs `recovered -> restoring`.

Plus the supervisor + config UI were already verified: real RTMP source killed/restored with the program routing main→fallback→main, and the settings form driven in a browser writing the config to the DB.

43 tests pass; `clippy --all-targets` clean.

## Scope (confirmed earlier)
Program-level, one global fallback, auto switch-back. The fallback is any source — a BRB image/video card or a backup live ingress.