### PR TITLE
docs: refresh README logo + features

### DIFF
--- a/.github/images/logo.svg
+++ b/.github/images/logo.svg
@@ -1,0 +1,8 @@
+<svg width="330" height="76" viewBox="0 0 330 76" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="MUXSHED">
+  <rect width="330" height="76" rx="14" fill="#120d07"/>
+  <!-- aperture mark -->
+  <circle cx="42" cy="38" r="15" fill="none" stroke="#ffb000" stroke-width="4"/>
+  <circle cx="42" cy="38" r="5" fill="#ffb000"/>
+  <!-- wordmark -->
+  <text x="76" y="47" font-family="'JetBrains Mono','IBM Plex Mono',ui-monospace,'SF Mono',Menlo,monospace" font-size="27" font-weight="700" letter-spacing="6.5" fill="#ffd479">MUXSHED</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src=".github/images/logo.png" alt="Muxshed" width="280" />
+<img src=".github/images/logo.svg" alt="Muxshed" width="300" />
 
 # Muxshed
 
@@ -18,11 +18,18 @@ This started years ago as a passion project to understand the complexities of mu
 
 - RTMP and SRT ingest from OBS, encoders, or any streaming software
 - Fan-out to YouTube, Twitch, Kick, and any custom RTMP/RTMPS endpoint
+- **Program failover** — when your source goes offline (e.g. an IRL stream drops), the
+  program automatically switches to a fallback source (a "be right back" image/video or a
+  backup ingress) so your destinations stay connected, then switches back when it returns
 - **Public watch page** — broadcast to your own self-hosted, unlisted `/watch/<token>`
   page with optional viewer password and custom branding (no external destination required)
-- Scene management with multi-layer compositor
+- Scene management with a multi-layer compositor and per-layer fit (fill / contain / cover)
+- **Browser and media sources** — add a live web page, or an image/video from the library,
+  as a scene layer
+- Audio mixer — per-source levels, mute, and audio-follows-video routing
+- Media library for images, video, and overlays
 - Stinger transitions with frame-accurate marker editing
-- Image overlays and lower thirds
+- Image overlays
 - Local recording
 - WebRTC guest links
 - API key authentication
@@ -165,7 +172,7 @@ cd system/docker
 docker compose up --build
 ```
 
-Builds the full production image with GStreamer and all plugins. Ports:
+Builds the production image (ffmpeg-based — the GStreamer feature is not built). Ports:
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
@@ -213,6 +220,8 @@ Key endpoints:
 POST   /api/v1/stream/start          Start streaming to all enabled destinations
 POST   /api/v1/stream/stop           Stop streaming
 GET    /api/v1/status                Pipeline state
+
+GET    /api/v1/failover              Program failover config (PUT to update)
 
 GET    /api/v1/sources               List sources
 POST   /api/v1/sources               Create source (auto-generates RTMP stream key)


### PR DESCRIPTION
## Logo
Replaces the old shed image with the website's brand mark — the amber aperture + `MUXSHED` wordmark (`.github/images/logo.svg`, built to the site's exact tokens: `#ffb000` / `#ffd479` on `#120d07`, JetBrains Mono).

## README was not fully up to date — fixed
- **Added shipped features that were missing**: program failover (fallback on source drop), per-layer fit modes (fill/contain/cover), browser + image/video sources, audio mixer, media library.
- **Fixed the production Docker section** — it claimed "GStreamer and all plugins"; the image is ffmpeg-based and the GStreamer feature isn't built (now matches the Dockerfile and the architecture note).
- Added `/failover` to the API endpoint sample.
- Removed the "lower thirds" claim (not implemented).