### PR TITLE
docs: add Discord community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ One stream in, or many. Every destination, simultaneously. No cloud middleman, n
 
 The open source, self-hosted alternative to Restream, StreamYard, and vMix.
 
+**[Join the community on Discord →](https://discord.gg/CZYjFu6vu)**
+
 <img src=".github/images/studio_screenshot.png" alt="Muxshed Studio" width="400" />
 
 ## Inspiration


### PR DESCRIPTION
Adds the Discord invite (https://discord.gg/CZYjFu6vu) under the tagline in the README.