### PR TITLE
VOD scheduling — Phase 1 (scheduled VOD premiere)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +479,17 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -1682,6 +1715,8 @@ dependencies = [
  "bcrypt",
  "bytes",
  "chrono",
+ "chrono-tz",
+ "cron",
  "futures-util",
  "hex",
  "http-body-util",
@@ -1920,6 +1955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1993,44 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2556,6 +2638,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -14,6 +14,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+cron = "0.12"
+chrono-tz = "0.9"
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 axum = { version = "0.8", features = ["ws", "multipart"] }

--- a/crates/api/src/failover.rs
+++ b/crates/api/src/failover.rs
@@ -141,7 +141,7 @@ async fn monitor(
                     );
                     ensure_fallback_running(state, fallback).await;
                     route(state, Some(fallback));
-                    restart_egress(state, fallback).await;
+                    crate::egress_restart_for(state, fallback).await;
                     showing_fallback = true;
                     recovering_since = None;
                     set_failover(state, true, Some(fallback), Some(intended)).await;
@@ -153,7 +153,7 @@ async fn monitor(
                         if now.duration_since(since) > recovery {
                             tracing::info!("failover: program source {} recovered -> restoring", intended);
                             route(state, Some(intended));
-                            restart_egress(state, intended).await;
+                            crate::egress_restart_for(state, intended).await;
                             showing_fallback = false;
                             recovering_since = None;
                             set_failover(state, false, Some(fallback), Some(intended)).await;
@@ -162,16 +162,6 @@ async fn monitor(
                 }
             }
         }
-    }
-}
-
-/// When live, restart the egress with a fresh encoder so the destination gets a
-/// clean stream across the program splice (a single long-running encoder chokes
-/// on a mid-stream source change). No-op in studio mode (egress not running).
-async fn restart_egress(state: &AppState, source: Uuid) {
-    if state.egress.is_running().await {
-        let seq = state.sequence_headers.read().await.get(&source).cloned();
-        state.egress.restart(seq).await;
     }
 }
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -7,6 +7,7 @@ pub mod failover;
 pub mod guest_webrtc;
 pub mod media_player;
 pub mod media_probe;
+pub mod playout;
 pub mod source_normalizer;
 pub mod srt;
 pub mod error;
@@ -17,3 +18,12 @@ pub mod browser_source;
 pub mod scene_compositor;
 pub mod schedule_time;
 pub mod state;
+
+/// Restart the egress with a fresh encoder primed for `source`, when live.
+/// Shared by the failover supervisor and the playout controller.
+pub async fn egress_restart_for(state: &std::sync::Arc<crate::state::AppState>, source: uuid::Uuid) {
+    if state.egress.is_running().await {
+        let seq = state.sequence_headers.read().await.get(&source).cloned();
+        state.egress.restart(seq).await;
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -17,6 +17,7 @@ pub mod rtmp;
 pub mod browser_source;
 pub mod scene_compositor;
 pub mod schedule_time;
+pub mod scheduler;
 pub mod state;
 
 /// Restart the egress with a fresh encoder primed for `source`, when live.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -15,4 +15,5 @@ pub mod routes;
 pub mod rtmp;
 pub mod browser_source;
 pub mod scene_compositor;
+pub mod schedule_time;
 pub mod state;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -83,6 +83,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (program_source_tx, _program_source_rx) = watch::channel::<Option<uuid::Uuid>>(None);
     let (program_intent_tx, _program_intent_rx) = watch::channel::<Option<uuid::Uuid>>(None);
     let (failover_active_tx, _failover_active_rx) = watch::channel::<bool>(false);
+    let (active_schedule_tx, _active_schedule_rx) = watch::channel::<Option<uuid::Uuid>>(None);
+    let (schedule_nudge_tx, _schedule_nudge_rx) = watch::channel::<u64>(0);
     let saved_audio_routing: muxshed_api::state::AudioRouting = sqlx::query_as::<_, (String,)>(
         "SELECT value FROM settings WHERE key = 'audio_routing'",
     )
@@ -121,6 +123,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         program_source: program_source_tx,
         program_intent: program_intent_tx,
         failover_active: failover_active_tx,
+        active_schedule: active_schedule_tx,
+        schedule_nudge: schedule_nudge_tx,
         preview_source: RwLock::new(None),
         audio_routing: audio_routing_tx,
         system_token,

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -192,6 +192,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         muxshed_api::failover::run_failover_supervisor(failover_state).await;
     });
 
+    let scheduler_state = state.clone();
+    tokio::spawn(async move {
+        muxshed_api::scheduler::run_scheduler(scheduler_state).await;
+    });
+
     let rtmp_state = state.clone();
     let rtmp_port = config.rtmp_port;
     tokio::spawn(async move {

--- a/crates/api/src/playout.rs
+++ b/crates/api/src/playout.rs
@@ -1,0 +1,251 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! Playout controller: airs a schedule's content to program + destinations.
+//! Phase 1 = a single VOD with a standby card around it and duration-based end.
+
+use crate::state::AppState;
+use muxshed_common::{DestinationKind, EndBehavior, WsEvent};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+struct VodItem {
+    asset_id: Uuid,
+    file_path: PathBuf,
+    duration_ms: u64,
+}
+
+/// Air the schedule now. Spawns a task that runs the broadcast and returns.
+pub async fn start_broadcast(state: Arc<AppState>, schedule_id: Uuid) {
+    tokio::spawn(async move {
+        if let Err(e) = run_broadcast(&state, schedule_id).await {
+            tracing::warn!("playout: broadcast {} error: {}", schedule_id, e);
+            record_run(&state, schedule_id, "error").await;
+            let _ = state.active_schedule.send(None);
+        }
+    });
+}
+
+async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), String> {
+    let vod = load_first_vod(state, schedule_id).await?;
+    let end_behavior = load_end_behavior(state, schedule_id).await;
+    let standby_asset = load_standby_asset(state, schedule_id).await;
+    let destinations = load_destinations(state, schedule_id).await;
+
+    let _ = state.active_schedule.send(Some(schedule_id));
+    record_run(state, schedule_id, "ran").await;
+    let _ = state.ws_tx.send(WsEvent::ScheduleStarted { id: schedule_id });
+    tracing::info!("playout: schedule {} on air (vod {})", schedule_id, vod.asset_id);
+
+    let standby_id = ensure_standby(state, &standby_asset).await;
+    let cfg = load_output_config(state).await;
+    let seq = if let Some(sid) = standby_id {
+        state.sequence_headers.read().await.get(&sid).cloned()
+    } else {
+        None
+    };
+    if let Err(e) = state
+        .egress
+        .start(schedule_id, destinations, state.program_tx.clone(), Some(cfg), seq)
+        .await
+    {
+        tracing::warn!("playout: egress start error (continuing): {}", e);
+    }
+    if let Some(sid) = standby_id {
+        let _ = state.program_intent.send(Some(sid));
+    }
+    state.pipeline.start(Vec::new()).await.ok();
+
+    let vod_source = Uuid::new_v4();
+    let loop_mode = if matches!(end_behavior, EndBehavior::Loop) {
+        "loop"
+    } else {
+        "one_shot"
+    };
+    crate::media_player::start_media_playback(state.clone(), vod_source, &vod.file_path, loop_mode)
+        .await
+        .map_err(|e| format!("vod playback: {}", e))?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let _ = state.program_intent.send(Some(vod_source));
+    crate::egress_restart_for(state, vod_source).await;
+
+    if !matches!(end_behavior, EndBehavior::Loop) {
+        let dur = Duration::from_millis(vod.duration_ms.max(1000));
+        tokio::select! {
+            _ = tokio::time::sleep(dur) => {}
+            _ = wait_until_deactivated(state, schedule_id) => {
+                crate::media_player::stop_media_playback(state, &vod_source).await;
+                return Ok(());
+            }
+        }
+        crate::media_player::stop_media_playback(state, &vod_source).await;
+        match end_behavior {
+            EndBehavior::Standby => {
+                if let Some(sid) = standby_id {
+                    let _ = state.program_intent.send(Some(sid));
+                    crate::egress_restart_for(state, sid).await;
+                }
+            }
+            _ => {
+                state.egress.stop().await;
+                state.pipeline.stop().await.ok();
+                let _ = state.program_intent.send(None);
+                if let Some(sid) = standby_id {
+                    crate::media_player::stop_media_playback(state, &sid).await;
+                }
+                let _ = state.active_schedule.send(None);
+                let _ = state.ws_tx.send(WsEvent::ScheduleEnded { id: schedule_id });
+                mark_run_ended(state, schedule_id).await;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Stop the currently-airing broadcast (manual stop).
+pub async fn stop_broadcast(state: &AppState) {
+    let id = *state.active_schedule.borrow();
+    state.egress.stop().await;
+    state.pipeline.stop().await.ok();
+    let _ = state.program_intent.send(None);
+    let _ = state.active_schedule.send(None);
+    if let Some(id) = id {
+        let _ = state.ws_tx.send(WsEvent::ScheduleEnded { id });
+        mark_run_ended(state, id).await;
+    }
+}
+
+async fn wait_until_deactivated(state: &Arc<AppState>, schedule_id: Uuid) {
+    let mut rx = state.active_schedule.subscribe();
+    loop {
+        if *rx.borrow_and_update() != Some(schedule_id) {
+            return;
+        }
+        if rx.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn ensure_standby(state: &Arc<AppState>, standby: &Option<VodItem>) -> Option<Uuid> {
+    let s = standby.as_ref()?;
+    let id = Uuid::new_v4();
+    let _ = crate::media_player::start_media_playback(state.clone(), id, &s.file_path, "loop").await;
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    Some(id)
+}
+
+async fn load_first_vod(state: &AppState, schedule_id: Uuid) -> Result<VodItem, String> {
+    let row = sqlx::query_as::<_, (String,)>(
+        "SELECT ref_id FROM schedule_items WHERE schedule_id = ? AND item_kind = 'vod' ORDER BY position ASC LIMIT 1",
+    )
+    .bind(schedule_id.to_string())
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| e.to_string())?
+    .ok_or("schedule has no VOD item")?;
+    let asset_id: Uuid = row.0.parse().map_err(|_| "bad asset id")?;
+    let a = sqlx::query_as::<_, (String, i64)>("SELECT file_path, duration_ms FROM assets WHERE id = ?")
+        .bind(asset_id.to_string())
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("VOD asset not found")?;
+    Ok(VodItem {
+        asset_id,
+        file_path: PathBuf::from(a.0),
+        duration_ms: a.1.max(0) as u64,
+    })
+}
+
+async fn load_standby_asset(state: &AppState, schedule_id: Uuid) -> Option<VodItem> {
+    let sid: Option<(Option<String>,)> =
+        sqlx::query_as("SELECT standby_asset_id FROM schedules WHERE id = ?")
+            .bind(schedule_id.to_string())
+            .fetch_optional(&state.db)
+            .await
+            .ok()
+            .flatten();
+    let asset_id = sid.and_then(|r| r.0)?;
+    let a = sqlx::query_as::<_, (String, i64)>("SELECT file_path, duration_ms FROM assets WHERE id = ?")
+        .bind(&asset_id)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()?;
+    Some(VodItem {
+        asset_id: asset_id.parse().ok()?,
+        file_path: PathBuf::from(a.0),
+        duration_ms: a.1.max(0) as u64,
+    })
+}
+
+async fn load_end_behavior(state: &AppState, schedule_id: Uuid) -> EndBehavior {
+    sqlx::query_as::<_, (String,)>("SELECT end_behavior FROM schedules WHERE id = ?")
+        .bind(schedule_id.to_string())
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .map(|r| EndBehavior::from_db(&r.0))
+        .unwrap_or_default()
+}
+
+async fn load_destinations(state: &AppState, schedule_id: Uuid) -> Vec<muxshed_common::Destination> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT destination_ids FROM schedules WHERE id = ?")
+        .bind(schedule_id.to_string())
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten();
+    let ids: Vec<String> = row.and_then(|r| serde_json::from_str(&r.0).ok()).unwrap_or_default();
+    let mut out = Vec::new();
+    for id in ids {
+        if let Ok(Some(d)) = sqlx::query_as::<_, (String, String, String, i64)>(
+            "SELECT id, name, kind, enabled FROM destinations WHERE id = ?",
+        )
+        .bind(&id)
+        .fetch_optional(&state.db)
+        .await
+        {
+            if let Ok(kind) = serde_json::from_str::<DestinationKind>(&d.2) {
+                out.push(muxshed_common::Destination {
+                    id: d.0.parse().unwrap_or_default(),
+                    name: d.1,
+                    kind,
+                    enabled: d.3 != 0,
+                });
+            }
+        }
+    }
+    out
+}
+
+async fn load_output_config(state: &AppState) -> crate::routes::output::OutputConfig {
+    sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key = 'output_config'")
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|(j,)| serde_json::from_str(&j).ok())
+        .unwrap_or_default()
+}
+
+async fn record_run(state: &AppState, schedule_id: Uuid, status: &str) {
+    let _ = sqlx::query("INSERT INTO schedule_runs (id, schedule_id, started_at, status) VALUES (?, ?, ?, ?)")
+        .bind(Uuid::new_v4().to_string())
+        .bind(schedule_id.to_string())
+        .bind(chrono::Utc::now().to_rfc3339())
+        .bind(status)
+        .execute(&state.db)
+        .await;
+}
+
+async fn mark_run_ended(state: &AppState, schedule_id: Uuid) {
+    let _ = sqlx::query("UPDATE schedule_runs SET ended_at = ? WHERE schedule_id = ? AND ended_at IS NULL")
+        .bind(chrono::Utc::now().to_rfc3339())
+        .bind(schedule_id.to_string())
+        .execute(&state.db)
+        .await;
+}

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -13,6 +13,7 @@ mod keys;
 pub mod output;
 mod recording;
 mod scenes;
+mod schedules;
 mod setup;
 mod sources;
 mod status;
@@ -94,6 +95,12 @@ pub fn build_router(state: Arc<AppState>, web_dir: Option<std::path::PathBuf>) -
         // Output config and stats
         .route("/output/config", get(output::get_config).put(output::set_config))
         .route("/failover", get(failover::get_config).put(failover::set_config))
+        // Schedules
+        .route("/schedules", get(schedules::list).post(schedules::create))
+        .route("/schedules/{id}", put(schedules::update).delete(schedules::delete))
+        .route("/schedules/{id}/run", post(schedules::run_now))
+        .route("/schedules/stop", post(schedules::stop))
+        .route("/settings/timezone", get(schedules::get_timezone).put(schedules::set_timezone))
         .route(
             "/webrtc/config",
             get(webrtc_config::get_config).put(webrtc_config::set_config),

--- a/crates/api/src/routes/schedules.rs
+++ b/crates/api/src/routes/schedules.rs
@@ -1,0 +1,205 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+use std::str::FromStr;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::error::ApiError;
+use crate::schedule_time::{next_run_after, parse_tz};
+use crate::state::AppState;
+use muxshed_common::{EndBehavior, MuxshedError, Schedule, ScheduleItem, ScheduleItemKind, TriggerKind};
+
+#[derive(Deserialize)]
+pub struct CreateItem { pub kind: ScheduleItemKind, pub ref_id: Uuid }
+
+#[derive(Deserialize)]
+pub struct UpsertSchedule {
+    pub name: String,
+    #[serde(default = "yes")] pub enabled: bool,
+    pub trigger: TriggerKind,
+    #[serde(default)] pub destination_ids: Vec<Uuid>,
+    pub standby_asset_id: Option<Uuid>,
+    #[serde(default)] pub end_behavior: EndBehavior,
+    pub until_at: Option<String>,
+    #[serde(default)] pub items: Vec<CreateItem>,
+}
+fn yes() -> bool { true }
+
+fn six(expr: &str) -> String {
+    let p: Vec<&str> = expr.split_whitespace().collect();
+    if p.len() == 5 { format!("0 {}", expr.trim()) } else { expr.trim().to_string() }
+}
+
+fn validate(u: &UpsertSchedule) -> Result<(), MuxshedError> {
+    match &u.trigger {
+        TriggerKind::Cron { expr } => {
+            cron::Schedule::from_str(&six(expr))
+                .map_err(|_| MuxshedError::BadRequest("invalid cron expression".into()))?;
+        }
+        TriggerKind::Once { at } => {
+            chrono::NaiveDateTime::parse_from_str(at, "%Y-%m-%dT%H:%M:%S")
+                .or_else(|_| chrono::NaiveDateTime::parse_from_str(at, "%Y-%m-%dT%H:%M"))
+                .map_err(|_| MuxshedError::BadRequest("invalid datetime".into()))?;
+        }
+    }
+    Ok(())
+}
+
+fn bump() -> u64 { chrono::Utc::now().timestamp_millis() as u64 }
+
+async fn system_tz(state: &AppState) -> chrono_tz::Tz {
+    let name = sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key='system_timezone'")
+        .fetch_optional(&state.db).await.ok().flatten().map(|r| r.0).unwrap_or_else(|| "UTC".into());
+    parse_tz(&name)
+}
+
+fn trigger_cols(t: &TriggerKind) -> (&'static str, Option<String>, Option<String>) {
+    match t {
+        TriggerKind::Once { at } => ("once", Some(at.clone()), None),
+        TriggerKind::Cron { expr } => ("cron", None, Some(expr.clone())),
+    }
+}
+
+pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<Schedule>>, ApiError> {
+    let ids = sqlx::query_as::<_, (String,)>("SELECT id FROM schedules ORDER BY created_at DESC")
+        .fetch_all(&state.db).await?;
+    let mut out = Vec::new();
+    for (id,) in ids { if let Some(s) = load_schedule(&state, &id).await? { out.push(s); } }
+    Ok(Json(out))
+}
+
+pub async fn create(
+    State(state): State<Arc<AppState>>, Json(body): Json<UpsertSchedule>,
+) -> Result<(StatusCode, Json<Schedule>), ApiError> {
+    validate(&body)?;
+    let id = Uuid::new_v4();
+    let now = chrono::Utc::now().to_rfc3339();
+    let (kind, at, cron) = trigger_cols(&body.trigger);
+    let next = next_run_after(&body.trigger, system_tz(&state).await, chrono::Utc::now()).map(|d| d.to_rfc3339());
+    sqlx::query("INSERT INTO schedules \
+        (id,name,enabled,trigger_kind,trigger_at,trigger_cron,destination_ids,standby_asset_id,end_behavior,until_at,next_run_at,created_at,updated_at) \
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)")
+        .bind(id.to_string()).bind(&body.name).bind(body.enabled as i64)
+        .bind(kind).bind(at).bind(cron)
+        .bind(serde_json::to_string(&body.destination_ids).unwrap_or_else(|_| "[]".into()))
+        .bind(body.standby_asset_id.map(|x| x.to_string()))
+        .bind(body.end_behavior.as_str()).bind(&body.until_at).bind(next)
+        .bind(&now).bind(&now)
+        .execute(&state.db).await?;
+    replace_items(&state, &id, &body.items).await?;
+    let _ = state.schedule_nudge.send(bump());
+    let s = load_schedule(&state, &id.to_string()).await?.ok_or_else(|| MuxshedError::Internal("load".into()))?;
+    Ok((StatusCode::CREATED, Json(s)))
+}
+
+pub async fn update(
+    State(state): State<Arc<AppState>>, Path(id): Path<String>, Json(body): Json<UpsertSchedule>,
+) -> Result<Json<Schedule>, ApiError> {
+    validate(&body)?;
+    let (kind, at, cron) = trigger_cols(&body.trigger);
+    let next = next_run_after(&body.trigger, system_tz(&state).await, chrono::Utc::now()).map(|d| d.to_rfc3339());
+    let res = sqlx::query("UPDATE schedules SET name=?,enabled=?,trigger_kind=?,trigger_at=?,trigger_cron=?,\
+        destination_ids=?,standby_asset_id=?,end_behavior=?,until_at=?,next_run_at=?,updated_at=? WHERE id=?")
+        .bind(&body.name).bind(body.enabled as i64).bind(kind).bind(at).bind(cron)
+        .bind(serde_json::to_string(&body.destination_ids).unwrap_or_else(|_| "[]".into()))
+        .bind(body.standby_asset_id.map(|x| x.to_string())).bind(body.end_behavior.as_str())
+        .bind(&body.until_at).bind(next).bind(chrono::Utc::now().to_rfc3339()).bind(&id)
+        .execute(&state.db).await?;
+    if res.rows_affected() == 0 { return Err(MuxshedError::NotFound(format!("schedule {id}")).into()); }
+    let sid: Uuid = id.parse().map_err(|_| MuxshedError::BadRequest("bad id".into()))?;
+    replace_items(&state, &sid, &body.items).await?;
+    let _ = state.schedule_nudge.send(bump());
+    Ok(Json(load_schedule(&state, &id).await?.ok_or_else(|| MuxshedError::NotFound(id.clone()))?))
+}
+
+pub async fn delete(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Result<StatusCode, ApiError> {
+    let r = sqlx::query("DELETE FROM schedules WHERE id=?").bind(&id).execute(&state.db).await?;
+    if r.rows_affected() == 0 { return Err(MuxshedError::NotFound(format!("schedule {id}")).into()); }
+    let _ = state.schedule_nudge.send(bump());
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn run_now(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Result<StatusCode, ApiError> {
+    let sid: Uuid = id.parse().map_err(|_| MuxshedError::BadRequest("bad id".into()))?;
+    if state.active_schedule.borrow().is_some() {
+        return Err(MuxshedError::BadRequest("already live".into()).into());
+    }
+    crate::playout::start_broadcast(state.clone(), sid).await;
+    Ok(StatusCode::OK)
+}
+
+pub async fn stop(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
+    crate::playout::stop_broadcast(&state).await;
+    Ok(StatusCode::OK)
+}
+
+#[derive(Deserialize)]
+pub struct TzBody { pub timezone: String }
+
+pub async fn get_timezone(State(state): State<Arc<AppState>>) -> Result<Json<serde_json::Value>, ApiError> {
+    let tz = sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key='system_timezone'")
+        .fetch_optional(&state.db).await?.map(|r| r.0).unwrap_or_else(|| "UTC".into());
+    Ok(Json(serde_json::json!({ "timezone": tz })))
+}
+
+pub async fn set_timezone(State(state): State<Arc<AppState>>, Json(b): Json<TzBody>) -> Result<Json<serde_json::Value>, ApiError> {
+    if b.timezone.parse::<chrono_tz::Tz>().is_err() {
+        return Err(MuxshedError::BadRequest("unknown timezone".into()).into());
+    }
+    sqlx::query("INSERT OR REPLACE INTO settings (key,value) VALUES ('system_timezone', ?)")
+        .bind(&b.timezone).execute(&state.db).await?;
+    recompute_all(&state).await?;
+    let _ = state.schedule_nudge.send(bump());
+    Ok(Json(serde_json::json!({ "timezone": b.timezone })))
+}
+
+async fn replace_items(state: &AppState, schedule_id: &Uuid, items: &[CreateItem]) -> Result<(), ApiError> {
+    sqlx::query("DELETE FROM schedule_items WHERE schedule_id=?").bind(schedule_id.to_string()).execute(&state.db).await?;
+    for (i, it) in items.iter().enumerate() {
+        sqlx::query("INSERT INTO schedule_items (id,schedule_id,position,item_kind,ref_id) VALUES (?,?,?,?,?)")
+            .bind(Uuid::new_v4().to_string()).bind(schedule_id.to_string())
+            .bind(i as i64).bind(it.kind.as_str()).bind(it.ref_id.to_string())
+            .execute(&state.db).await?;
+    }
+    Ok(())
+}
+
+async fn recompute_all(state: &AppState) -> Result<(), ApiError> {
+    let tz = system_tz(state).await;
+    let rows = sqlx::query_as::<_, (String, String, Option<String>, Option<String>)>(
+        "SELECT id,trigger_kind,trigger_at,trigger_cron FROM schedules WHERE enabled=1").fetch_all(&state.db).await?;
+    for (id, kind, at, cron) in rows {
+        let t = if kind == "cron" { TriggerKind::Cron { expr: cron.unwrap_or_default() } }
+                else { TriggerKind::Once { at: at.unwrap_or_default() } };
+        let next = next_run_after(&t, tz, chrono::Utc::now()).map(|d| d.to_rfc3339());
+        sqlx::query("UPDATE schedules SET next_run_at=? WHERE id=?").bind(next).bind(id).execute(&state.db).await?;
+    }
+    Ok(())
+}
+
+async fn load_schedule(state: &AppState, id: &str) -> Result<Option<Schedule>, ApiError> {
+    let row = sqlx::query_as::<_, (String,String,i64,String,Option<String>,Option<String>,String,Option<String>,String,Option<String>,Option<String>)>(
+        "SELECT id,name,enabled,trigger_kind,trigger_at,trigger_cron,destination_ids,standby_asset_id,end_behavior,until_at,next_run_at FROM schedules WHERE id=?")
+        .bind(id).fetch_optional(&state.db).await?;
+    let Some(r) = row else { return Ok(None) };
+    let items = sqlx::query_as::<_, (String,i64,String,String)>(
+        "SELECT id,position,item_kind,ref_id FROM schedule_items WHERE schedule_id=? ORDER BY position")
+        .bind(id).fetch_all(&state.db).await?
+        .into_iter().map(|(iid,pos,k,ref_id)| ScheduleItem {
+            id: iid.parse().unwrap_or_default(), position: pos as u32,
+            kind: ScheduleItemKind::from_db(&k), ref_id: ref_id.parse().unwrap_or_default(),
+        }).collect();
+    let trigger = if r.3 == "cron" { TriggerKind::Cron { expr: r.5.unwrap_or_default() } }
+                  else { TriggerKind::Once { at: r.4.unwrap_or_default() } };
+    Ok(Some(Schedule {
+        id: r.0.parse().unwrap_or_default(), name: r.1, enabled: r.2 != 0, trigger,
+        destination_ids: serde_json::from_str(&r.6).unwrap_or_default(),
+        standby_asset_id: r.7.and_then(|s| s.parse().ok()),
+        end_behavior: EndBehavior::from_db(&r.8), until_at: r.9,
+        items, next_run_at: r.10,
+    }))
+}

--- a/crates/api/src/schedule_time.rs
+++ b/crates/api/src/schedule_time.rs
@@ -1,0 +1,83 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! Pure next-run computation for schedule triggers, evaluated in a system
+//! timezone. DST-correct: "20:00 daily" stays 20:00 local across clock changes.
+
+use chrono::{DateTime, TimeZone, Utc};
+use chrono_tz::Tz;
+use muxshed_common::TriggerKind;
+use std::str::FromStr;
+
+/// Parse an IANA timezone name; falls back to UTC on anything unknown.
+pub fn parse_tz(name: &str) -> Tz {
+    name.parse::<Tz>().unwrap_or(chrono_tz::UTC)
+}
+
+/// The `cron` crate expects a 6-field expression (with seconds). We accept the
+/// standard 5-field form from users and prepend a "0" seconds field.
+fn to_six_field(expr: &str) -> String {
+    let parts: Vec<&str> = expr.split_whitespace().collect();
+    if parts.len() == 5 { format!("0 {}", expr.trim()) } else { expr.trim().to_string() }
+}
+
+/// Next run strictly after `after` (a UTC instant), for the given trigger in `tz`.
+/// Returns None for one-offs already in the past, or an unparseable cron.
+pub fn next_run_after(trigger: &TriggerKind, tz: Tz, after: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    match trigger {
+        TriggerKind::Once { at } => {
+            let naive = chrono::NaiveDateTime::parse_from_str(at, "%Y-%m-%dT%H:%M:%S")
+                .or_else(|_| chrono::NaiveDateTime::parse_from_str(at, "%Y-%m-%dT%H:%M"))
+                .ok()?;
+            let local = tz.from_local_datetime(&naive).single()?;
+            let utc = local.with_timezone(&Utc);
+            if utc > after { Some(utc) } else { None }
+        }
+        TriggerKind::Cron { expr } => {
+            let schedule = cron::Schedule::from_str(&to_six_field(expr)).ok()?;
+            let after_local = after.with_timezone(&tz);
+            schedule.after(&after_local).next().map(|dt| dt.with_timezone(&Utc))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn utc(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn daily_cron_holds_local_time_across_dst() {
+        let tz = parse_tz("Europe/London");
+        let after = utc("2026-03-28T19:30:00Z"); // 19:30 GMT, before spring-forward (last Sun of March = Mar 29)
+        let next = next_run_after(&TriggerKind::Cron { expr: "0 20 * * *".into() }, tz, after).unwrap();
+        assert_eq!(next, utc("2026-03-28T20:00:00Z")); // 20:00 London still GMT == 20:00Z
+
+        let after2 = utc("2026-03-30T10:00:00Z");
+        let next2 = next_run_after(&TriggerKind::Cron { expr: "0 20 * * *".into() }, tz, after2).unwrap();
+        assert_eq!(next2, utc("2026-03-30T19:00:00Z")); // 20:00 London now BST == 19:00Z
+    }
+
+    #[test]
+    fn once_in_past_is_none() {
+        let tz = parse_tz("UTC");
+        let after = utc("2026-07-02T21:00:00Z");
+        assert!(next_run_after(&TriggerKind::Once { at: "2026-07-02T20:00:00".into() }, tz, after).is_none());
+    }
+
+    #[test]
+    fn once_future_converts_local_to_utc() {
+        let tz = parse_tz("America/New_York"); // UTC-4 in July (EDT)
+        let after = utc("2026-07-02T10:00:00Z");
+        let next = next_run_after(&TriggerKind::Once { at: "2026-07-02T20:00:00".into() }, tz, after).unwrap();
+        assert_eq!(next, utc("2026-07-03T00:00:00Z")); // 20:00 EDT == 00:00Z next day
+    }
+
+    #[test]
+    fn bad_cron_is_none() {
+        let tz = parse_tz("UTC");
+        assert!(next_run_after(&TriggerKind::Cron { expr: "not a cron".into() }, tz, Utc::now()).is_none());
+    }
+}

--- a/crates/api/src/scheduler.rs
+++ b/crates/api/src/scheduler.rs
@@ -1,0 +1,113 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! Scheduler supervisor. Fires each enabled schedule when its persisted
+//! `next_run_at` (computed in the system timezone, DST-correct) comes due, then
+//! advances it. Skips with a notification if a broadcast is already live.
+
+use crate::schedule_time::{next_run_after, parse_tz};
+use crate::state::AppState;
+use chrono::{DateTime, Utc};
+use muxshed_common::{TriggerKind, WsEvent};
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+pub async fn run_scheduler(state: Arc<AppState>) {
+    let mut nudge = state.schedule_nudge.subscribe();
+    loop {
+        ensure_next_runs(&state).await;
+        let now = Utc::now();
+
+        for (id, trigger) in due_schedules(&state, now).await {
+            handle_due(&state, id, &trigger).await;
+        }
+
+        let sleep_for = soonest_next_run(&state).await
+            .map(|t| (t - Utc::now()).to_std().unwrap_or(Duration::from_secs(0)))
+            .unwrap_or(Duration::from_secs(60))
+            .clamp(Duration::from_millis(200), Duration::from_secs(60));
+
+        tokio::select! {
+            _ = tokio::time::sleep(sleep_for) => {}
+            r = nudge.changed() => { if r.is_err() { return; } }
+        }
+    }
+}
+
+async fn handle_due(state: &Arc<AppState>, id: Uuid, trigger: &TriggerKind) {
+    let live = state.active_schedule.borrow().is_some()
+        || matches!(state.pipeline.state().await, muxshed_common::PipelineState::Live { .. });
+    if live {
+        tracing::info!("scheduler: skipping {} — already live", id);
+        let _ = sqlx::query("INSERT INTO schedule_runs (id, schedule_id, status) VALUES (?, ?, 'skipped')")
+            .bind(Uuid::new_v4().to_string()).bind(id.to_string()).execute(&state.db).await;
+        let _ = state.ws_tx.send(WsEvent::ScheduleSkipped { id, reason: "already live".into() });
+    } else {
+        tracing::info!("scheduler: firing schedule {}", id);
+        crate::playout::start_broadcast(state.clone(), id).await;
+    }
+    advance(state, id, trigger).await;
+}
+
+/// Move a schedule past the occurrence just handled: one-offs are disabled;
+/// recurring schedules get their next future `next_run_at`.
+async fn advance(state: &Arc<AppState>, id: Uuid, trigger: &TriggerKind) {
+    match trigger {
+        TriggerKind::Once { .. } => {
+            let _ = sqlx::query("UPDATE schedules SET enabled = 0, next_run_at = NULL WHERE id = ?")
+                .bind(id.to_string()).execute(&state.db).await;
+        }
+        TriggerKind::Cron { .. } => {
+            let tz = parse_tz(&load_system_tz(state).await);
+            let next = next_run_after(trigger, tz, Utc::now()).map(|d| d.to_rfc3339());
+            let _ = sqlx::query("UPDATE schedules SET next_run_at = ? WHERE id = ?")
+                .bind(next).bind(id.to_string()).execute(&state.db).await;
+        }
+    }
+}
+
+/// Enabled schedules whose next_run_at is due (<= now).
+async fn due_schedules(state: &AppState, now: DateTime<Utc>) -> Vec<(Uuid, TriggerKind)> {
+    let rows = sqlx::query_as::<_, (String, String, Option<String>, Option<String>)>(
+        "SELECT id, trigger_kind, trigger_at, trigger_cron FROM schedules \
+         WHERE enabled = 1 AND next_run_at IS NOT NULL AND next_run_at <= ?",
+    ).bind(now.to_rfc3339()).fetch_all(&state.db).await.unwrap_or_default();
+    rows.into_iter().filter_map(|(id, kind, at, cron)| {
+        let sid: Uuid = id.parse().ok()?;
+        let trigger = if kind == "cron" { TriggerKind::Cron { expr: cron.unwrap_or_default() } }
+                      else { TriggerKind::Once { at: at.unwrap_or_default() } };
+        Some((sid, trigger))
+    }).collect()
+}
+
+/// Backfill next_run_at for enabled schedules without one; mark past one-offs missed.
+async fn ensure_next_runs(state: &AppState) {
+    let tz = parse_tz(&load_system_tz(state).await);
+    let rows = sqlx::query_as::<_, (String, String, Option<String>, Option<String>)>(
+        "SELECT id, trigger_kind, trigger_at, trigger_cron FROM schedules WHERE enabled = 1 AND next_run_at IS NULL",
+    ).fetch_all(&state.db).await.unwrap_or_default();
+    for (id, kind, at, cron) in rows {
+        let trigger = if kind == "cron" { TriggerKind::Cron { expr: cron.unwrap_or_default() } }
+                      else { TriggerKind::Once { at: at.unwrap_or_default() } };
+        if let Some(next) = next_run_after(&trigger, tz, Utc::now()) {
+            let _ = sqlx::query("UPDATE schedules SET next_run_at = ? WHERE id = ?")
+                .bind(next.to_rfc3339()).bind(&id).execute(&state.db).await;
+        } else if matches!(trigger, TriggerKind::Once { .. }) {
+            let _ = sqlx::query("UPDATE schedules SET enabled = 0 WHERE id = ?").bind(&id).execute(&state.db).await;
+            let _ = sqlx::query("INSERT INTO schedule_runs (id, schedule_id, status) VALUES (?, ?, 'missed')")
+                .bind(Uuid::new_v4().to_string()).bind(&id).execute(&state.db).await;
+        }
+    }
+}
+
+async fn soonest_next_run(state: &AppState) -> Option<DateTime<Utc>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT next_run_at FROM schedules WHERE enabled = 1 AND next_run_at IS NOT NULL ORDER BY next_run_at ASC LIMIT 1")
+        .fetch_optional(&state.db).await.ok().flatten();
+    row.and_then(|(s,)| DateTime::parse_from_rfc3339(&s).ok()).map(|d| d.with_timezone(&Utc))
+}
+
+async fn load_system_tz(state: &AppState) -> String {
+    sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key = 'system_timezone'")
+        .fetch_optional(&state.db).await.ok().flatten().map(|r| r.0).unwrap_or_else(|| "UTC".into())
+}

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -44,6 +44,10 @@ pub struct AppState {
     pub program_intent: watch::Sender<Option<Uuid>>,
     /// Whether a failover is currently engaged (program is on the fallback).
     pub failover_active: watch::Sender<bool>,
+    /// The schedule whose broadcast is currently on air (None = manual/idle).
+    pub active_schedule: watch::Sender<Option<Uuid>>,
+    /// Bumped whenever schedules or the system timezone change, to wake the scheduler.
+    pub schedule_nudge: watch::Sender<u64>,
     /// Which source is in preview (next to go live)
     pub preview_source: RwLock<Option<Uuid>>,
     /// Audio routing: which sources are providing audio and at what level

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -853,3 +853,35 @@ async fn test_browser_source_create() {
     let resp = app.oneshot(json_request("GET", &format!("/api/v1/sources/{}", id), &key, None)).await.unwrap();
     assert_eq!(response_json(resp).await["kind"]["url"], "https://example.com/overlay");
 }
+
+#[tokio::test]
+async fn test_schedule_crud_and_timezone() {
+    let (app, key, _state) = setup().await;
+
+    // set system timezone
+    let req = json_request("PUT", "/api/v1/settings/timezone", &key, Some(r#"{"timezone":"Europe/London"}"#));
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // create a valid cron schedule
+    let body = r#"{"name":"Nightly","enabled":true,"trigger":{"kind":"cron","expr":"0 20 * * *"},"destination_ids":[],"end_behavior":"stop","items":[{"kind":"vod","ref_id":"00000000-0000-0000-0000-000000000000"}]}"#;
+    let req = json_request("POST", "/api/v1/schedules", &key, Some(body));
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created = response_json(resp).await;
+    assert_eq!(created["name"], "Nightly");
+    assert_eq!(created["items"].as_array().unwrap().len(), 1);
+
+    // list
+    let req = json_request("GET", "/api/v1/schedules", &key, None);
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let list = response_json(resp).await;
+    assert_eq!(list.as_array().unwrap().len(), 1);
+
+    // reject bad cron
+    let bad = r#"{"name":"x","trigger":{"kind":"cron","expr":"nope nope nope"},"destination_ids":[],"items":[]}"#;
+    let req = json_request("POST", "/api/v1/schedules", &key, Some(bad));
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -24,6 +24,8 @@ async fn setup() -> (axum::Router<()>, String, Arc<AppState>) {
     let (program_source_tx, _) = tokio::sync::watch::channel::<Option<uuid::Uuid>>(None);
     let (program_intent_tx, _) = tokio::sync::watch::channel::<Option<uuid::Uuid>>(None);
     let (failover_active_tx, _) = tokio::sync::watch::channel::<bool>(false);
+    let (active_schedule_tx, _) = tokio::sync::watch::channel::<Option<uuid::Uuid>>(None);
+    let (schedule_nudge_tx, _) = tokio::sync::watch::channel::<u64>(0);
     let (audio_routing_tx, _) = tokio::sync::watch::channel(muxshed_api::state::AudioRouting::default());
     let pipeline = Arc::new(StubPipelineController::new(ws_tx.clone()));
 
@@ -70,6 +72,8 @@ async fn setup() -> (axum::Router<()>, String, Arc<AppState>) {
         program_source: program_source_tx,
         program_intent: program_intent_tx,
         failover_active: failover_active_tx,
+        active_schedule: active_schedule_tx,
+        schedule_nudge: schedule_nudge_tx,
         preview_source: tokio::sync::RwLock::new(None),
         audio_routing: audio_routing_tx,
         system_token: None,

--- a/crates/common/src/events.rs
+++ b/crates/common/src/events.rs
@@ -42,6 +42,9 @@ pub enum WsEvent {
         /// The operator-selected source the failover is standing in for.
         intent_source_id: Option<Uuid>,
     },
+    ScheduleStarted { id: Uuid },
+    ScheduleEnded { id: Uuid },
+    ScheduleSkipped { id: Uuid, reason: String },
     Error {
         message: String,
         code: String,

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -209,6 +209,83 @@ impl Default for FailoverConfig {
     }
 }
 
+/// How a broadcast ends when its content finishes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EndBehavior {
+    #[default]
+    Stop,
+    Loop,
+    Standby,
+}
+
+impl EndBehavior {
+    pub fn as_str(&self) -> &'static str {
+        match self { EndBehavior::Stop => "stop", EndBehavior::Loop => "loop", EndBehavior::Standby => "standby" }
+    }
+    pub fn from_db(s: &str) -> Self {
+        match s { "loop" => EndBehavior::Loop, "standby" => EndBehavior::Standby, _ => EndBehavior::Stop }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduleItemKind {
+    Vod,
+    Scene,
+    Source,
+}
+
+impl ScheduleItemKind {
+    pub fn as_str(&self) -> &'static str {
+        match self { ScheduleItemKind::Vod => "vod", ScheduleItemKind::Scene => "scene", ScheduleItemKind::Source => "source" }
+    }
+    pub fn from_db(s: &str) -> Self {
+        match s { "scene" => ScheduleItemKind::Scene, "source" => ScheduleItemKind::Source, _ => ScheduleItemKind::Vod }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TriggerKind {
+    /// One-off local datetime in the system timezone, e.g. "2026-07-02T20:00:00".
+    Once { at: String },
+    /// 5-field cron (min hour dom mon dow), evaluated in the system timezone.
+    Cron { expr: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduleItem {
+    pub id: Uuid,
+    pub position: u32,
+    pub kind: ScheduleItemKind,
+    pub ref_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Schedule {
+    pub id: Uuid,
+    pub name: String,
+    pub enabled: bool,
+    pub trigger: TriggerKind,
+    pub destination_ids: Vec<Uuid>,
+    pub standby_asset_id: Option<Uuid>,
+    pub end_behavior: EndBehavior,
+    pub until_at: Option<String>,
+    pub items: Vec<ScheduleItem>,
+    /// Computed next fire time as an RFC3339 UTC instant. None = not scheduled.
+    pub next_run_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduleRun {
+    pub id: Uuid,
+    pub schedule_id: Uuid,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+    pub status: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelConfig {
     pub enabled: bool,
@@ -428,5 +505,29 @@ mod tests {
             audio_behaviour: StingerAudio::Duck(0.2),
             thumbnail_path: "/s.png".into(),
         });
+    }
+
+    #[test]
+    fn schedule_types_roundtrip() {
+        let s = Schedule {
+            id: Uuid::nil(),
+            name: "Premiere".into(),
+            enabled: true,
+            trigger: TriggerKind::Cron { expr: "0 20 * * *".into() },
+            destination_ids: vec![Uuid::nil()],
+            standby_asset_id: Some(Uuid::nil()),
+            end_behavior: EndBehavior::Stop,
+            until_at: None,
+            items: vec![ScheduleItem { id: Uuid::nil(), position: 0, kind: ScheduleItemKind::Vod, ref_id: Uuid::nil() }],
+            next_run_at: None,
+        };
+        let back: Schedule = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert_eq!(back.name, "Premiere");
+        assert!(matches!(back.trigger, TriggerKind::Cron { .. }));
+        assert!(matches!(back.end_behavior, EndBehavior::Stop));
+        let v = serde_json::to_value(EndBehavior::Loop).unwrap();
+        assert_eq!(v, serde_json::json!("loop"));
+        let t = serde_json::to_value(TriggerKind::Once { at: "2026-07-02T20:00:00".into() }).unwrap();
+        assert_eq!(t["kind"], "once");
     }
 }

--- a/migrations/009_schedules.sql
+++ b/migrations/009_schedules.sql
@@ -1,0 +1,35 @@
+-- Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+CREATE TABLE IF NOT EXISTS schedules (
+    id               TEXT PRIMARY KEY NOT NULL,
+    name             TEXT NOT NULL,
+    enabled          INTEGER NOT NULL DEFAULT 1,
+    trigger_kind     TEXT NOT NULL DEFAULT 'once',   -- 'once' | 'cron'
+    trigger_at       TEXT,                           -- ISO-8601 local (system tz), for 'once'
+    trigger_cron     TEXT,                           -- 5-field cron, for 'cron'
+    destination_ids  TEXT NOT NULL DEFAULT '[]',     -- JSON array of destination ids
+    standby_asset_id TEXT,
+    end_behavior     TEXT NOT NULL DEFAULT 'stop',   -- 'stop' | 'loop' | 'standby'
+    until_at         TEXT,                           -- optional hard stop (ISO local)
+    next_run_at      TEXT,                           -- computed UTC instant (RFC3339)
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schedule_items (
+    id          TEXT PRIMARY KEY NOT NULL,
+    schedule_id TEXT NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+    position    INTEGER NOT NULL DEFAULT 0,
+    item_kind   TEXT NOT NULL DEFAULT 'vod',         -- 'vod' | 'scene' | 'source'
+    ref_id      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schedule_runs (
+    id          TEXT PRIMARY KEY NOT NULL,
+    schedule_id TEXT NOT NULL,
+    started_at  TEXT,
+    ended_at    TEXT,
+    status      TEXT NOT NULL                        -- 'ran' | 'skipped' | 'error' | 'missed'
+);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_items_schedule ON schedule_items(schedule_id);

--- a/web/src/components/TimezonePicker.svelte
+++ b/web/src/components/TimezonePicker.svelte
@@ -1,0 +1,101 @@
+<!-- Licensed under the GNU Affero General Public License v3.0 — see LICENSE. -->
+<script lang="ts">
+	// Searchable timezone combobox. Stores the canonical IANA name (what the
+	// backend / chrono-tz accepts) but lets the operator search human-readably
+	// (e.g. "new york", "london", "berlin").
+	let { value = $bindable(''), onselect }: { value?: string; onselect?: (tz: string) => void } = $props();
+
+	// All IANA zones the runtime knows; underscores are the canonical form.
+	const zones: string[] = (() => {
+		try {
+			return Intl.supportedValuesOf?.('timeZone') ?? [];
+		} catch {
+			return [];
+		}
+	})();
+
+	let query = $state('');
+	let open = $state(false);
+	let active = $state(0);
+
+	function offset(tz: string): string {
+		try {
+			const part = new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'shortOffset' })
+				.formatToParts(new Date())
+				.find((p) => p.type === 'timeZoneName');
+			return part?.value ?? '';
+		} catch {
+			return '';
+		}
+	}
+	const norm = (s: string) => s.toLowerCase().replace(/[_/]/g, ' ');
+	const label = (tz: string) => tz.replace(/_/g, ' ');
+
+	const filtered = $derived.by(() => {
+		const q = norm(query.trim());
+		const list = q ? zones.filter((z) => norm(z).includes(q)) : zones;
+		return list.slice(0, 60);
+	});
+
+	function pick(tz: string) {
+		value = tz;
+		query = '';
+		open = false;
+		onselect?.(tz);
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (!open) return;
+		if (e.key === 'ArrowDown') { active = Math.min(active + 1, filtered.length - 1); e.preventDefault(); }
+		else if (e.key === 'ArrowUp') { active = Math.max(active - 1, 0); e.preventDefault(); }
+		else if (e.key === 'Enter' && filtered[active]) { pick(filtered[active]); e.preventDefault(); }
+		else if (e.key === 'Escape') { open = false; }
+	}
+</script>
+
+<div class="relative">
+	<input
+		class="input"
+		placeholder={value ? label(value) : 'Search timezone…'}
+		bind:value={query}
+		onfocus={() => { open = true; active = 0; }}
+		oninput={() => { open = true; active = 0; }}
+		onkeydown={onKeydown}
+		onblur={() => setTimeout(() => (open = false), 150)}
+		role="combobox"
+		aria-expanded={open}
+		aria-controls="tz-listbox"
+		aria-label="Timezone"
+	/>
+	{#if value && !open}
+		<span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-amber-muted">{offset(value)}</span>
+	{/if}
+
+	{#if open}
+		<ul
+			id="tz-listbox"
+			role="listbox"
+			class="absolute z-50 mt-1 max-h-64 w-full overflow-y-auto rounded border border-border bg-panel-raised shadow-lg"
+		>
+			{#if filtered.length === 0}
+				<li class="px-3 py-2 text-xs text-amber-muted">No match</li>
+			{:else}
+				{#each filtered as tz, i (tz)}
+					<li>
+						<button
+							type="button"
+							class="flex w-full items-center justify-between px-3 py-1.5 text-left text-[13px] hover:bg-panel {i === active ? 'bg-panel text-amber-bright' : 'text-amber-dim'} {tz === value ? 'text-amber' : ''}"
+							onmousedown={() => pick(tz)}
+							onmouseenter={() => (active = i)}
+							role="option"
+							aria-selected={tz === value}
+						>
+							<span>{label(tz)}</span>
+							<span class="ml-3 shrink-0 text-[11px] text-amber-muted">{offset(tz)}</span>
+						</button>
+					</li>
+				{/each}
+			{/if}
+		</ul>
+	{/if}
+</div>

--- a/web/src/components/TimezonePicker.svelte
+++ b/web/src/components/TimezonePicker.svelte
@@ -17,6 +17,32 @@
 	let query = $state('');
 	let open = $state(false);
 	let active = $state(0);
+	let inputEl = $state<HTMLInputElement | null>(null);
+	// The dropdown is a fixed-position popover anchored to the input's screen
+	// rect, so it isn't clipped by the settings panel's overflow.
+	let rect = $state({ top: 0, left: 0, width: 0 });
+
+	function place() {
+		if (!inputEl) return;
+		const r = inputEl.getBoundingClientRect();
+		rect = { top: r.bottom, left: r.left, width: r.width };
+	}
+	function openList() {
+		open = true;
+		active = 0;
+		place();
+	}
+
+	$effect(() => {
+		if (!open) return;
+		const reposition = () => place();
+		window.addEventListener('scroll', reposition, true);
+		window.addEventListener('resize', reposition);
+		return () => {
+			window.removeEventListener('scroll', reposition, true);
+			window.removeEventListener('resize', reposition);
+		};
+	});
 
 	function offset(tz: string): string {
 		try {
@@ -55,11 +81,12 @@
 
 <div class="relative">
 	<input
+		bind:this={inputEl}
 		class="input"
 		placeholder={value ? label(value) : 'Search timezone…'}
 		bind:value={query}
-		onfocus={() => { open = true; active = 0; }}
-		oninput={() => { open = true; active = 0; }}
+		onfocus={openList}
+		oninput={openList}
 		onkeydown={onKeydown}
 		onblur={() => setTimeout(() => (open = false), 150)}
 		role="combobox"
@@ -75,7 +102,8 @@
 		<ul
 			id="tz-listbox"
 			role="listbox"
-			class="absolute z-50 mt-1 max-h-64 w-full overflow-y-auto rounded border border-border bg-panel-raised shadow-lg"
+			class="fixed z-50 max-h-64 overflow-y-auto rounded border border-border bg-panel-raised shadow-lg"
+			style="top: {rect.top}px; left: {rect.left}px; width: {rect.width}px;"
 		>
 			{#if filtered.length === 0}
 				<li class="px-3 py-2 text-xs text-amber-muted">No match</li>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,6 @@
 // Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
 
-import type { Source, SourceKind, Destination, DestinationKind, ApiKey, Scene, Layer, LayerFit, RecordingState, StingerConfig, StingerAudio, Guest, BroadcastConfig, OutputConfig, OutputStats, AudioRouting, Asset, AssetFolder, User, ChannelConfig, WebrtcConfig, FailoverConfig } from './types';
+import type { Source, SourceKind, Destination, DestinationKind, ApiKey, Scene, Layer, LayerFit, RecordingState, StingerConfig, StingerAudio, Guest, BroadcastConfig, OutputConfig, OutputStats, AudioRouting, Asset, AssetFolder, User, ChannelConfig, WebrtcConfig, FailoverConfig, Schedule } from './types';
 
 function getSessionToken(): string {
 	if (typeof window === 'undefined') return '';
@@ -146,6 +146,16 @@ export const api = {
 	setFailover: (config: FailoverConfig) =>
 		request<FailoverConfig>('/failover', { method: 'PUT', body: JSON.stringify(config) }),
 	getOutputStats: () => request<OutputStats>('/output/stats'),
+
+	// Schedules (VOD scheduling)
+	listSchedules: () => request<Schedule[]>('/schedules'),
+	createSchedule: (s: object) => request<Schedule>('/schedules', { method: 'POST', body: JSON.stringify(s) }),
+	updateSchedule: (id: string, s: object) => request<Schedule>(`/schedules/${id}`, { method: 'PUT', body: JSON.stringify(s) }),
+	deleteSchedule: (id: string) => request<void>(`/schedules/${id}`, { method: 'DELETE' }),
+	runSchedule: (id: string) => request<void>(`/schedules/${id}/run`, { method: 'POST' }),
+	stopSchedule: () => request<void>('/schedules/stop', { method: 'POST' }),
+	getTimezone: () => request<{ timezone: string }>('/settings/timezone'),
+	setTimezone: (timezone: string) => request<{ timezone: string }>('/settings/timezone', { method: 'PUT', body: JSON.stringify({ timezone }) }),
 
 	// WebRTC / guest ICE config
 	getWebrtcConfig: () => request<WebrtcConfig>('/webrtc/config'),

--- a/web/src/lib/stores/pipeline.ts
+++ b/web/src/lib/stores/pipeline.ts
@@ -13,6 +13,7 @@ export const failover = writable<{
 	fallback_source_id: string | null;
 	intent_source_id: string | null;
 }>({ active: false, fallback_source_id: null, intent_source_id: null });
+export const activeSchedule = writable<{ id: string | null }>({ id: null });
 
 export const isLive = derived(pipelineState, ($s) => $s.state === 'live');
 export const isTransitioning = derived(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -71,6 +71,18 @@ export interface Scene {
 	layers: Layer[];
 }
 
+export type EndBehavior = 'stop' | 'loop' | 'standby';
+export type ScheduleItemKind = 'vod' | 'scene' | 'source';
+export type Trigger = { kind: 'once'; at: string } | { kind: 'cron'; expr: string };
+
+export interface ScheduleItem { id: string; position: number; kind: ScheduleItemKind; ref_id: string; }
+export interface Schedule {
+	id: string; name: string; enabled: boolean; trigger: Trigger;
+	destination_ids: string[]; standby_asset_id: string | null;
+	end_behavior: EndBehavior; until_at: string | null;
+	items: ScheduleItem[]; next_run_at: string | null;
+}
+
 export interface User {
 	id: string;
 	username: string;
@@ -240,4 +252,7 @@ export type WsEvent =
 			type: 'failover_state';
 			payload: { active: boolean; fallback_source_id: string | null; intent_source_id: string | null };
 	  }
+	| { type: 'schedule_started'; payload: { id: string } }
+	| { type: 'schedule_ended'; payload: { id: string } }
+	| { type: 'schedule_skipped'; payload: { id: string; reason: string } }
 	| { type: 'error'; payload: { message: string; code: string } };

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,7 +1,8 @@
 // Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
 
-import { pipelineState, sources, destinations, recordingState, failover } from './stores/pipeline';
+import { pipelineState, sources, destinations, recordingState, failover, activeSchedule } from './stores/pipeline';
 import type { WsEvent } from './types';
+import { notify } from '$lib/notify';
 
 let ws: WebSocket | null = null;
 let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -93,6 +94,15 @@ function handleEvent(event: WsEvent) {
 				fallback_source_id: event.payload.fallback_source_id,
 				intent_source_id: event.payload.intent_source_id,
 			});
+			break;
+		case 'schedule_started':
+			activeSchedule.set({ id: event.payload.id });
+			break;
+		case 'schedule_ended':
+			activeSchedule.set({ id: null });
+			break;
+		case 'schedule_skipped':
+			notify.info(`Schedule skipped: ${event.payload.reason}`);
 			break;
 	}
 }

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -143,6 +143,7 @@
 		{ href: '/', label: 'Studio' },
 		{ href: '/sources', label: 'Sources' },
 		{ href: '/scenes', label: 'Scenes' },
+		{ href: '/schedules', label: 'Schedules' },
 		{ href: '/library', label: 'Library' },
 		{ href: '/destinations', label: 'Destinations' },
 		{ href: '/guests', label: 'Guests' },

--- a/web/src/routes/(app)/schedules/+page.svelte
+++ b/web/src/routes/(app)/schedules/+page.svelte
@@ -1,0 +1,207 @@
+<!-- Licensed under the GNU Affero General Public License v3.0 — see LICENSE. -->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api';
+	import { notify } from '$lib/notify';
+	import { activeSchedule } from '$lib/stores/pipeline';
+	import type { Schedule, Asset, Destination } from '$lib/types';
+
+	let schedules = $state<Schedule[]>([]);
+	let assets = $state<Asset[]>([]);
+	let destinations = $state<Destination[]>([]);
+	let tz = $state('UTC');
+
+	let editing = $state<Schedule | null>(null);
+	let name = $state('');
+	let triggerKind = $state<'once' | 'cron'>('cron');
+	let cron = $state('0 20 * * *');
+	let onceAt = $state('');
+	let vodId = $state('');
+	let standbyId = $state('');
+	let endBehavior = $state<'stop' | 'loop' | 'standby'>('stop');
+	let destIds = $state<string[]>([]);
+
+	onMount(refresh);
+	async function refresh() {
+		const [s, a, d, t] = await Promise.all([
+			api.listSchedules(),
+			api.listAssets(),
+			api.listDestinations(),
+			api.getTimezone(),
+		]);
+		schedules = s;
+		assets = a.filter((x) => x.asset_type === 'video');
+		destinations = d;
+		tz = t.timezone;
+	}
+
+	function newSchedule() {
+		editing = { id: '' } as Schedule;
+		name = '';
+		triggerKind = 'cron';
+		cron = '0 20 * * *';
+		onceAt = '';
+		vodId = assets[0]?.id ?? '';
+		standbyId = '';
+		endBehavior = 'stop';
+		destIds = [];
+	}
+
+	function payload() {
+		const trigger = triggerKind === 'cron' ? { kind: 'cron', expr: cron } : { kind: 'once', at: onceAt };
+		return {
+			name,
+			enabled: true,
+			trigger,
+			destination_ids: destIds,
+			standby_asset_id: standbyId || null,
+			end_behavior: endBehavior,
+			until_at: null,
+			items: [{ kind: 'vod', ref_id: vodId }],
+		};
+	}
+
+	async function save() {
+		if (!vodId) {
+			notify.error('Pick a VOD');
+			return;
+		}
+		try {
+			if (editing?.id) await api.updateSchedule(editing.id, payload());
+			else await api.createSchedule(payload());
+			editing = null;
+			await refresh();
+		} catch (e) {
+			notify.error(e);
+		}
+	}
+
+	async function toggle(s: Schedule) {
+		try {
+			await api.updateSchedule(s.id, {
+				name: s.name,
+				enabled: !s.enabled,
+				trigger: s.trigger,
+				destination_ids: s.destination_ids,
+				standby_asset_id: s.standby_asset_id,
+				end_behavior: s.end_behavior,
+				until_at: s.until_at,
+				items: s.items.map((i) => ({ kind: i.kind, ref_id: i.ref_id })),
+			});
+			await refresh();
+		} catch (e) {
+			notify.error(e);
+		}
+	}
+	async function del(s: Schedule) {
+		await api.deleteSchedule(s.id);
+		await refresh();
+	}
+	async function runNow(s: Schedule) {
+		try {
+			await api.runSchedule(s.id);
+		} catch (e) {
+			notify.error(e);
+		}
+	}
+
+	function nextRun(s: Schedule) {
+		return s.next_run_at ? new Date(s.next_run_at).toLocaleString() : '—';
+	}
+</script>
+
+<div class="mx-auto max-w-4xl">
+	<div class="row mb-4 items-center justify-between">
+		<div>
+			<h1 class="text-lg text-amber-bright tracking-widest">SCHEDULES</h1>
+			<p class="text-xs text-amber-dim">Timezone: {tz} · set it in Settings</p>
+		</div>
+		<button class="btn btn--go" onclick={newSchedule}>+ New schedule</button>
+	</div>
+
+	{#if $activeSchedule.id}
+		<div class="panel mb-3">
+			<div class="panel__body text-live">
+				● A scheduled broadcast is on air.
+				<button class="btn btn--ghost ml-2" onclick={() => api.stopSchedule()}>Stop</button>
+			</div>
+		</div>
+	{/if}
+
+	{#each schedules as s (s.id)}
+		<div class="panel mb-2">
+			<div class="panel__body row items-center justify-between">
+				<div>
+					<span class="text-amber">{s.name}</span>
+					<span class="ml-2 text-[11px] text-amber-muted">
+						{s.trigger.kind === 'cron' ? `cron ${s.trigger.expr}` : `once ${s.trigger.at}`} · next {nextRun(s)} · {s.end_behavior}
+					</span>
+				</div>
+				<div class="flex gap-1">
+					<button class="btn btn--ghost" onclick={() => runNow(s)}>Air now</button>
+					<button class="btn {s.enabled ? 'btn--go' : ''}" onclick={() => toggle(s)}>{s.enabled ? 'On' : 'Off'}</button>
+					<button class="btn btn--danger" onclick={() => del(s)}>✕</button>
+				</div>
+			</div>
+		</div>
+	{/each}
+
+	{#if editing}
+		<div class="panel mt-4">
+			<div class="panel__body">
+				<label class="field-label" for="s-name">Name</label>
+				<input id="s-name" bind:value={name} class="input mb-3" />
+
+				<label class="field-label" for="s-vod">VOD</label>
+				<select id="s-vod" bind:value={vodId} class="select mb-3 w-full">
+					{#each assets as a}<option value={a.id}>{a.name}</option>{/each}
+				</select>
+
+				<label class="field-label" for="s-trigger">Trigger</label>
+				<select id="s-trigger" bind:value={triggerKind} class="select mb-2 w-full">
+					<option value="cron">Recurring (cron)</option>
+					<option value="once">One-off (date/time)</option>
+				</select>
+				{#if triggerKind === 'cron'}
+					<input bind:value={cron} placeholder="0 20 * * *" class="input mb-3" />
+				{:else}
+					<input type="datetime-local" bind:value={onceAt} class="input mb-3" />
+				{/if}
+
+				<label class="field-label" for="s-end">When it ends</label>
+				<select id="s-end" bind:value={endBehavior} class="select mb-3 w-full">
+					<option value="stop">Stop (go offline)</option>
+					<option value="loop">Loop</option>
+					<option value="standby">Hold on standby</option>
+				</select>
+
+				<label class="field-label" for="s-standby">Standby card (optional)</label>
+				<select id="s-standby" bind:value={standbyId} class="select mb-3 w-full">
+					<option value="">— none —</option>
+					{#each assets as a}<option value={a.id}>{a.name}</option>{/each}
+				</select>
+
+				<span class="field-label">Destinations</span>
+				<div class="mb-3 flex flex-col gap-1">
+					{#each destinations as d}
+						<label class="flex items-center gap-2 text-xs">
+							<input
+								type="checkbox"
+								value={d.id}
+								checked={destIds.includes(d.id)}
+								onchange={(e) =>
+									(destIds = e.currentTarget.checked ? [...destIds, d.id] : destIds.filter((x) => x !== d.id))}
+							/>
+							{d.name}
+						</label>
+					{/each}
+				</div>
+
+				<div class="flex gap-2">
+					<button class="btn btn--go" onclick={save}>Save</button>
+					<button class="btn btn--ghost" onclick={() => (editing = null)}>Cancel</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/web/src/routes/(app)/settings/+page.svelte
+++ b/web/src/routes/(app)/settings/+page.svelte
@@ -4,6 +4,7 @@
 	import { api } from '$lib/api';
 	import { notify } from '$lib/notify';
 	import type { User, Source, FailoverConfig } from '$lib/types';
+	import TimezonePicker from '../../../components/TimezonePicker.svelte';
 
 	// Password change
 	let currentPassword = $state('');
@@ -338,8 +339,8 @@
 	<section class="panel">
 		<header class="panel__head">▮ System Timezone</header>
 		<div class="panel__body">
-			<p class="mb-2 text-xs text-amber-dim">All schedules are evaluated in this timezone (IANA name, e.g. Europe/London).</p>
-			<input bind:value={systemTz} placeholder="Europe/London" class="input mb-2" />
+			<p class="mb-2 text-xs text-amber-dim">All schedules are evaluated in this timezone. Search by city or region.</p>
+			<div class="mb-2"><TimezonePicker bind:value={systemTz} /></div>
 			<button onclick={saveTz} disabled={tzSaving} class="btn btn--go">{tzSaving ? 'Saving…' : 'Save timezone'}</button>
 		</div>
 	</section>

--- a/web/src/routes/(app)/settings/+page.svelte
+++ b/web/src/routes/(app)/settings/+page.svelte
@@ -34,11 +34,16 @@
 	let sources = $state<Source[]>([]);
 	let failoverSaving = $state(false);
 
+	// System timezone
+	let systemTz = $state('UTC');
+	let tzSaving = $state(false);
+
 	onMount(async () => {
 		fxOff = localStorage.getItem('muxshed-fx') === 'off';
 		await refreshUsers();
 		try {
 			[failover, sources] = await Promise.all([api.getFailover(), api.listSources()]);
+			systemTz = (await api.getTimezone()).timezone;
 		} catch (e) {
 			notify.error(e);
 		}
@@ -58,6 +63,13 @@
 		} finally {
 			failoverSaving = false;
 		}
+	}
+
+	async function saveTz() {
+		tzSaving = true;
+		try { systemTz = (await api.setTimezone(systemTz)).timezone; notify.success('Timezone saved'); }
+		catch (e) { notify.error(e); }
+		finally { tzSaving = false; }
 	}
 
 	function toggleFx() {
@@ -319,6 +331,16 @@
 			<button onclick={saveFailover} disabled={failoverSaving} class="btn btn--go mt-3">
 				{failoverSaving ? 'Saving…' : 'Save failover settings'}
 			</button>
+		</div>
+	</section>
+
+	<!-- System Timezone -->
+	<section class="panel">
+		<header class="panel__head">▮ System Timezone</header>
+		<div class="panel__body">
+			<p class="mb-2 text-xs text-amber-dim">All schedules are evaluated in this timezone (IANA name, e.g. Europe/London).</p>
+			<input bind:value={systemTz} placeholder="Europe/London" class="input mb-2" />
+			<button onclick={saveTz} disabled={tzSaving} class="btn btn--go">{tzSaving ? 'Saving…' : 'Save timezone'}</button>
 		</div>
 	</section>
 


### PR DESCRIPTION
Implements **Phase 1** of the [VOD playout & scheduling design](docs/superpowers/specs/2026-07-02-vod-playout-scheduling-design.md): schedule an uploaded VOD to auto-go-live to chosen destinations at a set time (one-off or cron, in an owner-set system timezone), play it out with a standby card around it, and auto-stop when it finishes. Built on a data model that makes Phases 2 (playlists / 24-7 channel) and 3 (any-content, recurrence UI) additive.

## What's in it
- **Migration 009** — `schedules`, `schedule_items`, `schedule_runs`.
- **DST-safe scheduling** — `schedule_time.rs`: next-run in the system timezone via `cron` + `chrono-tz` (unit-tested across a DST boundary — "20:00 daily" stays 20:00 local).
- **Scheduler supervisor** (`scheduler.rs`) — background task (failover-supervisor pattern) that fires each schedule's persisted `next_run_at` and advances it; **skips + notifies** if already live; marks missed one-offs.
- **Playout controller** (`playout.rs`) — airs the VOD to program + the schedule's destinations, reusing `media_player`, `program_intent`, `egress` + the failover **egress-restart** for a clean cut, a **standby card** (reusing the failover-fallback), and duration-based end.
- **Schedules API** — CRUD + run-now/stop + `GET/PUT /settings/timezone`.
- **Frontend** — a dedicated **Schedules** page (list + create/edit: VOD, cron/one-off, end behavior, standby, destinations), a nav item, and a system-timezone picker in Settings.
- DRY cleanup: the egress-restart helper is now shared by the failover supervisor and playout.

## Verified end-to-end
Against a real API + a persistent RTMP sink (`node-media-server`):
- A one-off VOD scheduled for T fired at **T + 6ms**; the **VOD content aired to the RTMP destination** (frame captured shows the testsrc VOD with its own burned-in timecode); it **auto-stopped** at the VOD's end (pipeline → idle, run = `ran`).
- A second schedule firing while live was **skipped** (run = `skipped`, `schedule_skipped` event).
- Drove the **Schedules page in a browser**: created a schedule through the UI → it persisted with the correct trigger, computed `next_run_at`, VOD item, and destination.

49 rust tests pass · `clippy --all-targets` clean · `svelte-check` 0 errors.
