### PR TITLE
VOD scheduling — Phase 2 (playlists & 24-7 channel)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This started years ago as a passion project to understand the complexities of mu
   backup ingress) so your destinations stay connected, then switches back when it returns
 - **Public watch page** — broadcast to your own self-hosted, unlisted `/watch/<token>`
   page with optional viewer password and custom branding (no external destination required)
+- **Scheduled broadcasts** — upload videos and have them go to air on their own, at a set
+  time or on a repeating schedule: a single premiere, a playlist, or a looping 24/7 channel
 - Scene management with a multi-layer compositor and per-layer fit (fill / contain / cover)
 - **Browser and media sources** — add a live web page, or an image/video from the library,
   as a scene layer
@@ -53,6 +55,21 @@ optionally add a viewer password, and share the unlisted link (`/watch/<token>`)
   when the broadcast begins — no refresh needed.
 - The link is unlisted; add a password to restrict it further. Regenerate the link any
   time to revoke access.
+
+## Scheduled Broadcasts
+
+Upload videos to the library and have them go to air on their own — no operator at the desk.
+Open the **Schedules** section and build a schedule from one or more videos.
+
+- Fire once at a set date and time, or repeat on a cron schedule. Times are evaluated in a
+  timezone you pick for the instance (set it under Settings), so DST is handled correctly.
+- Add several videos to a playlist and they play back-to-back as one continuous stream,
+  scaled onto a common canvas so mixed resolutions join cleanly.
+- Pick what happens when the playlist ends: stop, hold on a standby card, or loop the whole
+  playlist as an always-on 24/7 channel.
+- A scheduled broadcast airs to the destinations you choose (or every enabled destination)
+  and your public watch page, exactly like a manual go-live. Edit or air a schedule on
+  demand from the same screen.
 
 ## Stream Deck & Bitfocus Companion
 
@@ -238,6 +255,10 @@ POST   /api/v1/transition/stinger    Trigger stinger transition
 
 POST   /api/v1/record/start          Start recording
 POST   /api/v1/record/stop           Stop recording
+
+GET    /api/v1/schedules             List schedules
+POST   /api/v1/schedules             Create a schedule
+POST   /api/v1/schedules/:id/run     Air a schedule now
 
 GET    /api/v1/ws?key=API_KEY        WebSocket for real-time state updates
 ```

--- a/crates/api/src/channel_hls.rs
+++ b/crates/api/src/channel_hls.rs
@@ -107,6 +107,10 @@ impl ChannelHls {
             format!("{}k", cfg.audio_bitrate_kbps),
             "-ar".into(),
             "48000".into(),
+            // Downmix to stereo — the native AAC encoder rejects 5.1/6-channel input
+            // ("Unsupported channel layout"), and destinations want stereo anyway.
+            "-ac".into(),
+            "2".into(),
             "-f".into(),
             "hls".into(),
             "-hls_time".into(),

--- a/crates/api/src/egress.rs
+++ b/crates/api/src/egress.rs
@@ -131,6 +131,8 @@ impl EgressManager {
                 "-c:a".to_string(), "aac".to_string(),
                 "-b:a".to_string(), format!("{}k", cfg.audio_bitrate_kbps),
                 "-ar".to_string(), "48000".to_string(),
+                // Downmix to stereo: the native AAC encoder rejects 5.1/6-channel input.
+                "-ac".to_string(), "2".to_string(),
             ]);
 
             args.extend([

--- a/crates/api/src/media_player.rs
+++ b/crates/api/src/media_player.rs
@@ -169,7 +169,12 @@ pub async fn start_concat_playback(
     let list_path = data_dir.join(format!("playlist_{}.txt", source_id));
     let mut list = String::from("ffconcat version 1.0\n");
     for f in files {
-        let p = f.to_string_lossy().replace('\'', "'\\''");
+        // The concat demuxer resolves relative `file` entries against the list file's
+        // own directory, not the process cwd — so a relative data_dir (the default is
+        // "data") would double the prefix (data/data/library/...) and ffmpeg would fail
+        // to open the input. Canonicalize to an absolute path to sidestep that.
+        let abs = tokio::fs::canonicalize(f).await.unwrap_or_else(|_| f.clone());
+        let p = abs.to_string_lossy().replace('\'', "'\\''");
         list.push_str(&format!("file '{}'\n", p));
     }
     tokio::fs::write(&list_path, list).await.map_err(|e| format!("write playlist: {}", e))?;

--- a/crates/api/src/media_player.rs
+++ b/crates/api/src/media_player.rs
@@ -85,6 +85,9 @@ pub async fn start_media_playback(
             "128k".into(),
             "-ar".into(),
             "48000".into(),
+            // Downmix to stereo: the native AAC encoder rejects 5.1/6-channel input.
+            "-ac".into(),
+            "2".into(),
         ]);
     }
 
@@ -195,6 +198,7 @@ pub async fn start_concat_playback(
         "-tune".into(), "zerolatency".into(), "-pix_fmt".into(), "yuv420p".into(),
         "-g".into(), format!("{}", fps * 2), "-r".into(), format!("{}", fps), "-b:v".into(), "3000k".into(),
         "-c:a".into(), "aac".into(), "-b:a".into(), "128k".into(), "-ar".into(), "48000".into(),
+        "-ac".into(), "2".into(),
         "-f".into(), "flv".into(), "pipe:1".into(),
     ]);
 

--- a/crates/api/src/media_player.rs
+++ b/crates/api/src/media_player.rs
@@ -144,6 +144,85 @@ pub async fn start_media_playback(
     Ok(())
 }
 
+/// Play a playlist of video files as one seamless stream into the source's
+/// relay. Files are concatenated via ffmpeg's concat demuxer and scaled/padded
+/// to the output canvas so mixed-resolution VODs join cleanly. `loop_forever`
+/// repeats the whole playlist (a 24-7 channel).
+pub async fn start_concat_playback(
+    state: Arc<AppState>,
+    source_id: Uuid,
+    files: &[std::path::PathBuf],
+    loop_forever: bool,
+    width: u32,
+    height: u32,
+    fps: u32,
+) -> Result<(), String> {
+    if files.is_empty() {
+        return Err("empty playlist".into());
+    }
+    let relay_tx = state.get_or_create_media_relay(source_id).await;
+
+    // Write a concat list file. Single quotes in paths are escaped per the
+    // concat demuxer's rules ( ' -> '\'' ).
+    let data_dir = state.config.read().await.data_dir.clone();
+    let _ = tokio::fs::create_dir_all(&data_dir).await;
+    let list_path = data_dir.join(format!("playlist_{}.txt", source_id));
+    let mut list = String::from("ffconcat version 1.0\n");
+    for f in files {
+        let p = f.to_string_lossy().replace('\'', "'\\''");
+        list.push_str(&format!("file '{}'\n", p));
+    }
+    tokio::fs::write(&list_path, list).await.map_err(|e| format!("write playlist: {}", e))?;
+
+    let vf = format!(
+        "scale={}:{}:force_original_aspect_ratio=decrease,pad={}:{}:(ow-iw)/2:(oh-ih)/2:black,setsar=1",
+        width, height, width, height
+    );
+    let mut args: Vec<String> = vec!["-hide_banner".into(), "-loglevel".into(), "warning".into()];
+    if loop_forever {
+        args.extend(["-stream_loop".into(), "-1".into()]);
+    }
+    args.extend([
+        "-re".into(), "-f".into(), "concat".into(), "-safe".into(), "0".into(),
+        "-i".into(), list_path.to_string_lossy().into_owned(),
+        "-vf".into(), vf,
+        "-c:v".into(), "libx264".into(), "-preset".into(), "veryfast".into(),
+        "-tune".into(), "zerolatency".into(), "-pix_fmt".into(), "yuv420p".into(),
+        "-g".into(), format!("{}", fps * 2), "-r".into(), format!("{}", fps), "-b:v".into(), "3000k".into(),
+        "-c:a".into(), "aac".into(), "-b:a".into(), "128k".into(), "-ar".into(), "48000".into(),
+        "-f".into(), "flv".into(), "pipe:1".into(),
+    ]);
+
+    tracing::info!("starting concat playback for {} ({} items, loop={})", source_id, files.len(), loop_forever);
+    let mut child = Command::new("ffmpeg")
+        .args(&args).stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped())
+        .kill_on_drop(true).spawn().map_err(|e| format!("failed to start ffmpeg: {}", e))?;
+    let stdout = child.stdout.take().ok_or("no stdout")?;
+    if let Some(stderr) = child.stderr.take() {
+        let sid = source_id;
+        tokio::spawn(async move {
+            let mut reader = tokio::io::BufReader::new(stderr);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut line).await {
+                    Ok(0) => break,
+                    Ok(_) => tracing::debug!("ffmpeg concat [{}]: {}", sid, line.trim()),
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+    {
+        let mut players = state.media_players.write().await;
+        if let Some(mut old) = players.remove(&source_id) { let _ = old.kill().await; }
+        players.insert(source_id, child);
+    }
+    let sc = state.clone();
+    tokio::spawn(async move { feed_relay(source_id, stdout, relay_tx, sc).await; });
+    Ok(())
+}
+
 async fn feed_relay(
     source_id: Uuid,
     mut stdout: tokio::process::ChildStdout,

--- a/crates/api/src/playout.rs
+++ b/crates/api/src/playout.rs
@@ -62,6 +62,8 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
     tokio::time::sleep(Duration::from_millis(500)).await;
     let _ = state.program_intent.send(Some(vod_source));
     crate::egress_restart_for(state, vod_source).await;
+    // Bring the public Channel watch page on air, same as a manual go-live.
+    crate::routes::stream::ensure_channel_hls(state).await;
 
     if !matches!(end_behavior, EndBehavior::Loop) {
         let dur = Duration::from_millis(playlist.total_ms.max(1000));
@@ -78,10 +80,13 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
                 if let Some(sid) = standby_id {
                     let _ = state.program_intent.send(Some(sid));
                     crate::egress_restart_for(state, sid).await;
+                    // Follow the splice so the watch page keeps playing the standby card.
+                    crate::routes::stream::ensure_channel_hls(state).await;
                 }
             }
             _ => {
                 state.egress.stop().await;
+                state.channel_hls.stop().await;
                 state.pipeline.stop().await.ok();
                 let _ = state.program_intent.send(None);
                 if let Some(sid) = standby_id {
@@ -100,6 +105,7 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
 pub async fn stop_broadcast(state: &AppState) {
     let id = *state.active_schedule.borrow();
     state.egress.stop().await;
+    state.channel_hls.stop().await;
     state.pipeline.stop().await.ok();
     let _ = state.program_intent.send(None);
     let _ = state.active_schedule.send(None);

--- a/crates/api/src/playout.rs
+++ b/crates/api/src/playout.rs
@@ -64,34 +64,40 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
     // Bring the public Channel watch page on air, same as a manual go-live.
     crate::routes::stream::ensure_channel_hls(state).await;
 
-    if !matches!(end_behavior, EndBehavior::Loop) {
-        let dur = Duration::from_millis(playlist.total_ms.max(1000));
-        tokio::select! {
-            _ = tokio::time::sleep(dur) => {}
-            _ = wait_until_deactivated(state, schedule_id) => {
-                crate::media_player::stop_media_playback(state, &vod_source).await;
-                return Ok(());
+    if matches!(end_behavior, EndBehavior::Loop) {
+        // A 24/7 loop runs until the operator stops it. Wait for that, then stop the
+        // concat player so its ffmpeg doesn't linger past the broadcast.
+        wait_until_deactivated(state, schedule_id).await;
+        crate::media_player::stop_media_playback(state, &vod_source).await;
+        return Ok(());
+    }
+
+    let dur = Duration::from_millis(playlist.total_ms.max(1000));
+    tokio::select! {
+        _ = tokio::time::sleep(dur) => {}
+        _ = wait_until_deactivated(state, schedule_id) => {
+            crate::media_player::stop_media_playback(state, &vod_source).await;
+            return Ok(());
+        }
+    }
+    crate::media_player::stop_media_playback(state, &vod_source).await;
+    match end_behavior {
+        EndBehavior::Standby => {
+            if let Some(sid) = ensure_standby(state, &standby_asset).await {
+                let _ = state.program_intent.send(Some(sid));
+                crate::egress_restart_for(state, sid).await;
+                // Follow the splice so the watch page keeps playing the standby card.
+                crate::routes::stream::ensure_channel_hls(state).await;
             }
         }
-        crate::media_player::stop_media_playback(state, &vod_source).await;
-        match end_behavior {
-            EndBehavior::Standby => {
-                if let Some(sid) = ensure_standby(state, &standby_asset).await {
-                    let _ = state.program_intent.send(Some(sid));
-                    crate::egress_restart_for(state, sid).await;
-                    // Follow the splice so the watch page keeps playing the standby card.
-                    crate::routes::stream::ensure_channel_hls(state).await;
-                }
-            }
-            _ => {
-                state.egress.stop().await;
-                state.channel_hls.stop().await;
-                state.pipeline.stop().await.ok();
-                let _ = state.program_intent.send(None);
-                let _ = state.active_schedule.send(None);
-                let _ = state.ws_tx.send(WsEvent::ScheduleEnded { id: schedule_id });
-                mark_run_ended(state, schedule_id).await;
-            }
+        _ => {
+            state.egress.stop().await;
+            state.channel_hls.stop().await;
+            state.pipeline.stop().await.ok();
+            let _ = state.program_intent.send(None);
+            let _ = state.active_schedule.send(None);
+            let _ = state.ws_tx.send(WsEvent::ScheduleEnded { id: schedule_id });
+            mark_run_ended(state, schedule_id).await;
         }
     }
     Ok(())

--- a/crates/api/src/playout.rs
+++ b/crates/api/src/playout.rs
@@ -32,26 +32,15 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
     let _ = state.ws_tx.send(WsEvent::ScheduleStarted { id: schedule_id });
     tracing::info!("playout: schedule {} on air ({} VOD items)", schedule_id, playlist.files.len());
 
-    let standby_id = ensure_standby(state, &standby_asset).await;
     let cfg = load_output_config(state).await;
     let (out_w, out_h, out_fps) = (cfg.width, cfg.height, cfg.fps);
-    let seq = if let Some(sid) = standby_id {
-        state.sequence_headers.read().await.get(&sid).cloned()
-    } else {
-        None
-    };
-    if let Err(e) = state
-        .egress
-        .start(schedule_id, destinations, state.program_tx.clone(), Some(cfg), seq)
-        .await
-    {
-        tracing::warn!("playout: egress start error (continuing): {}", e);
-    }
-    if let Some(sid) = standby_id {
-        let _ = state.program_intent.send(Some(sid));
-    }
-    state.pipeline.start(Vec::new()).await.ok();
 
+    // Start the VOD playing into the program BEFORE connecting egress, so each
+    // destination gets one clean, continuous RTMP session from the first frame —
+    // the same way manual go-live only connects egress once the source is live.
+    // Connecting egress early and then restarting it on the program splice makes
+    // YouTube stick on "Preparing stream": it latches onto the first, dying
+    // publish and never promotes the reconnect.
     let vod_source = Uuid::new_v4();
     let loop_forever = matches!(end_behavior, EndBehavior::Loop);
     crate::media_player::start_concat_playback(
@@ -61,7 +50,17 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
     .map_err(|e| format!("playlist playback: {}", e))?;
     tokio::time::sleep(Duration::from_millis(500)).await;
     let _ = state.program_intent.send(Some(vod_source));
-    crate::egress_restart_for(state, vod_source).await;
+    state.pipeline.start(Vec::new()).await.ok();
+
+    // Connect egress once, with the VOD already flowing (no restart, no reconnect).
+    let seq = state.sequence_headers.read().await.get(&vod_source).cloned();
+    if let Err(e) = state
+        .egress
+        .start(schedule_id, destinations, state.program_tx.clone(), Some(cfg), seq)
+        .await
+    {
+        tracing::warn!("playout: egress start error (continuing): {}", e);
+    }
     // Bring the public Channel watch page on air, same as a manual go-live.
     crate::routes::stream::ensure_channel_hls(state).await;
 
@@ -77,7 +76,7 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
         crate::media_player::stop_media_playback(state, &vod_source).await;
         match end_behavior {
             EndBehavior::Standby => {
-                if let Some(sid) = standby_id {
+                if let Some(sid) = ensure_standby(state, &standby_asset).await {
                     let _ = state.program_intent.send(Some(sid));
                     crate::egress_restart_for(state, sid).await;
                     // Follow the splice so the watch page keeps playing the standby card.
@@ -89,9 +88,6 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
                 state.channel_hls.stop().await;
                 state.pipeline.stop().await.ok();
                 let _ = state.program_intent.send(None);
-                if let Some(sid) = standby_id {
-                    crate::media_player::stop_media_playback(state, &sid).await;
-                }
                 let _ = state.active_schedule.send(None);
                 let _ = state.ws_tx.send(WsEvent::ScheduleEnded { id: schedule_id });
                 mark_run_ended(state, schedule_id).await;

--- a/crates/api/src/playout.rs
+++ b/crates/api/src/playout.rs
@@ -207,23 +207,40 @@ async fn load_destinations(state: &AppState, schedule_id: Uuid) -> Vec<muxshed_c
         .ok()
         .flatten();
     let ids: Vec<String> = row.and_then(|r| serde_json::from_str(&r.0).ok()).unwrap_or_default();
-    let mut out = Vec::new();
-    for id in ids {
-        if let Ok(Some(d)) = sqlx::query_as::<_, (String, String, String, i64)>(
-            "SELECT id, name, kind, enabled FROM destinations WHERE id = ?",
-        )
-        .bind(&id)
-        .fetch_optional(&state.db)
-        .await
-        {
-            if let Ok(kind) = serde_json::from_str::<DestinationKind>(&d.2) {
-                out.push(muxshed_common::Destination {
-                    id: d.0.parse().unwrap_or_default(),
-                    name: d.1,
-                    kind,
-                    enabled: d.3 != 0,
-                });
+
+    // Mirror the manual go-live behaviour (routes/stream.rs): stream to the schedule's
+    // selected destinations that are enabled, or — when the schedule selects none — to
+    // every enabled destination. Only enabled destinations are ever used.
+    let rows: Vec<(String, String, String, i64)> = if ids.is_empty() {
+        sqlx::query_as("SELECT id, name, kind, enabled FROM destinations WHERE enabled = 1")
+            .fetch_all(&state.db)
+            .await
+            .unwrap_or_default()
+    } else {
+        let mut acc = Vec::new();
+        for id in &ids {
+            if let Ok(Some(d)) = sqlx::query_as::<_, (String, String, String, i64)>(
+                "SELECT id, name, kind, enabled FROM destinations WHERE id = ? AND enabled = 1",
+            )
+            .bind(id)
+            .fetch_optional(&state.db)
+            .await
+            {
+                acc.push(d);
             }
+        }
+        acc
+    };
+
+    let mut out = Vec::new();
+    for d in rows {
+        if let Ok(kind) = serde_json::from_str::<DestinationKind>(&d.2) {
+            out.push(muxshed_common::Destination {
+                id: d.0.parse().unwrap_or_default(),
+                name: d.1,
+                kind,
+                enabled: d.3 != 0,
+            });
         }
     }
     out

--- a/crates/api/src/playout.rs
+++ b/crates/api/src/playout.rs
@@ -10,12 +10,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
-struct VodItem {
-    asset_id: Uuid,
-    file_path: PathBuf,
-    duration_ms: u64,
-}
-
 /// Air the schedule now. Spawns a task that runs the broadcast and returns.
 pub async fn start_broadcast(state: Arc<AppState>, schedule_id: Uuid) {
     tokio::spawn(async move {
@@ -28,7 +22,7 @@ pub async fn start_broadcast(state: Arc<AppState>, schedule_id: Uuid) {
 }
 
 async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), String> {
-    let vod = load_first_vod(state, schedule_id).await?;
+    let playlist = load_playlist(state, schedule_id).await?;
     let end_behavior = load_end_behavior(state, schedule_id).await;
     let standby_asset = load_standby_asset(state, schedule_id).await;
     let destinations = load_destinations(state, schedule_id).await;
@@ -36,10 +30,11 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
     let _ = state.active_schedule.send(Some(schedule_id));
     record_run(state, schedule_id, "ran").await;
     let _ = state.ws_tx.send(WsEvent::ScheduleStarted { id: schedule_id });
-    tracing::info!("playout: schedule {} on air (vod {})", schedule_id, vod.asset_id);
+    tracing::info!("playout: schedule {} on air ({} VOD items)", schedule_id, playlist.files.len());
 
     let standby_id = ensure_standby(state, &standby_asset).await;
     let cfg = load_output_config(state).await;
+    let (out_w, out_h, out_fps) = (cfg.width, cfg.height, cfg.fps);
     let seq = if let Some(sid) = standby_id {
         state.sequence_headers.read().await.get(&sid).cloned()
     } else {
@@ -58,20 +53,18 @@ async fn run_broadcast(state: &Arc<AppState>, schedule_id: Uuid) -> Result<(), S
     state.pipeline.start(Vec::new()).await.ok();
 
     let vod_source = Uuid::new_v4();
-    let loop_mode = if matches!(end_behavior, EndBehavior::Loop) {
-        "loop"
-    } else {
-        "one_shot"
-    };
-    crate::media_player::start_media_playback(state.clone(), vod_source, &vod.file_path, loop_mode)
-        .await
-        .map_err(|e| format!("vod playback: {}", e))?;
+    let loop_forever = matches!(end_behavior, EndBehavior::Loop);
+    crate::media_player::start_concat_playback(
+        state.clone(), vod_source, &playlist.files, loop_forever, out_w, out_h, out_fps,
+    )
+    .await
+    .map_err(|e| format!("playlist playback: {}", e))?;
     tokio::time::sleep(Duration::from_millis(500)).await;
     let _ = state.program_intent.send(Some(vod_source));
     crate::egress_restart_for(state, vod_source).await;
 
     if !matches!(end_behavior, EndBehavior::Loop) {
-        let dur = Duration::from_millis(vod.duration_ms.max(1000));
+        let dur = Duration::from_millis(playlist.total_ms.max(1000));
         tokio::select! {
             _ = tokio::time::sleep(dur) => {}
             _ = wait_until_deactivated(state, schedule_id) => {
@@ -128,38 +121,50 @@ async fn wait_until_deactivated(state: &Arc<AppState>, schedule_id: Uuid) {
     }
 }
 
-async fn ensure_standby(state: &Arc<AppState>, standby: &Option<VodItem>) -> Option<Uuid> {
-    let s = standby.as_ref()?;
+async fn ensure_standby(state: &Arc<AppState>, standby: &Option<PathBuf>) -> Option<Uuid> {
+    let p = standby.as_ref()?;
     let id = Uuid::new_v4();
-    let _ = crate::media_player::start_media_playback(state.clone(), id, &s.file_path, "loop").await;
+    let _ = crate::media_player::start_media_playback(state.clone(), id, p, "loop").await;
     tokio::time::sleep(Duration::from_millis(400)).await;
     Some(id)
 }
 
-async fn load_first_vod(state: &AppState, schedule_id: Uuid) -> Result<VodItem, String> {
-    let row = sqlx::query_as::<_, (String,)>(
-        "SELECT ref_id FROM schedule_items WHERE schedule_id = ? AND item_kind = 'vod' ORDER BY position ASC LIMIT 1",
-    )
-    .bind(schedule_id.to_string())
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|e| e.to_string())?
-    .ok_or("schedule has no VOD item")?;
-    let asset_id: Uuid = row.0.parse().map_err(|_| "bad asset id")?;
-    let a = sqlx::query_as::<_, (String, i64)>("SELECT file_path, duration_ms FROM assets WHERE id = ?")
-        .bind(asset_id.to_string())
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|e| e.to_string())?
-        .ok_or("VOD asset not found")?;
-    Ok(VodItem {
-        asset_id,
-        file_path: PathBuf::from(a.0),
-        duration_ms: a.1.max(0) as u64,
-    })
+struct Playlist {
+    files: Vec<std::path::PathBuf>,
+    total_ms: u64,
 }
 
-async fn load_standby_asset(state: &AppState, schedule_id: Uuid) -> Option<VodItem> {
+async fn load_playlist(state: &AppState, schedule_id: Uuid) -> Result<Playlist, String> {
+    let rows = sqlx::query_as::<_, (String,)>(
+        "SELECT ref_id FROM schedule_items WHERE schedule_id = ? AND item_kind = 'vod' ORDER BY position ASC",
+    )
+    .bind(schedule_id.to_string())
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| e.to_string())?;
+    if rows.is_empty() {
+        return Err("schedule has no VOD items".into());
+    }
+    let mut files = Vec::new();
+    let mut total_ms = 0u64;
+    for (ref_id,) in rows {
+        let a = sqlx::query_as::<_, (String, i64)>("SELECT file_path, duration_ms FROM assets WHERE id = ?")
+            .bind(&ref_id)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|e| e.to_string())?;
+        if let Some((path, dur)) = a {
+            files.push(std::path::PathBuf::from(path));
+            total_ms += dur.max(0) as u64;
+        }
+    }
+    if files.is_empty() {
+        return Err("no playable VOD assets".into());
+    }
+    Ok(Playlist { files, total_ms })
+}
+
+async fn load_standby_asset(state: &AppState, schedule_id: Uuid) -> Option<std::path::PathBuf> {
     let sid: Option<(Option<String>,)> =
         sqlx::query_as("SELECT standby_asset_id FROM schedules WHERE id = ?")
             .bind(schedule_id.to_string())
@@ -168,17 +173,13 @@ async fn load_standby_asset(state: &AppState, schedule_id: Uuid) -> Option<VodIt
             .ok()
             .flatten();
     let asset_id = sid.and_then(|r| r.0)?;
-    let a = sqlx::query_as::<_, (String, i64)>("SELECT file_path, duration_ms FROM assets WHERE id = ?")
+    let a = sqlx::query_as::<_, (String,)>("SELECT file_path FROM assets WHERE id = ?")
         .bind(&asset_id)
         .fetch_optional(&state.db)
         .await
         .ok()
         .flatten()?;
-    Some(VodItem {
-        asset_id: asset_id.parse().ok()?,
-        file_path: PathBuf::from(a.0),
-        duration_ms: a.1.max(0) as u64,
-    })
+    Some(std::path::PathBuf::from(a.0))
 }
 
 async fn load_end_behavior(state: &AppState, schedule_id: Uuid) -> EndBehavior {

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -18,7 +18,7 @@ mod setup;
 mod sources;
 mod status;
 mod stingers;
-mod stream;
+pub mod stream;
 mod switching;
 pub mod webrtc_config;
 mod ws;

--- a/docs/superpowers/plans/2026-07-02-vod-scheduling-phase2.md
+++ b/docs/superpowers/plans/2026-07-02-vod-scheduling-phase2.md
@@ -1,0 +1,249 @@
+# VOD Scheduling — Phase 2 Implementation Plan (Playlists & 24-7 channel)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** A schedule can play a **playlist of VODs** (not just one), seamlessly, and **loop** it into an always-on 24-7 channel.
+
+**Architecture:** Pure-VOD playlists play through a single ffmpeg **concat** process (seamless between items), scaled/padded to the output canvas so mixed-resolution VODs concatenate cleanly. `end_behavior: loop` uses `-stream_loop -1`. Reuses the existing `feed_relay` FLV→relay pump, `program_intent`, egress + egress-restart. The data model (`schedule_items`) already supports multiple ordered items — this is additive.
+
+**Tech Stack:** Rust (Tokio, sqlx, ffmpeg concat demuxer), SvelteKit (Svelte 5, Tailwind).
+
+**Base:** branch `feat/vod-scheduling-p2` off `main` (Phase 1 merged). Conventions per `system/CLAUDE.md`.
+
+---
+
+## Task 1: Concat playlist playback in the media player
+
+**File:** `crates/api/src/media_player.rs` (add a function; reuse the existing `feed_relay`).
+
+- [ ] **Step 1: Add `start_concat_playback`.** Append to `media_player.rs`:
+
+```rust
+/// Play a playlist of video files as one seamless stream into the source's
+/// relay. Files are concatenated via ffmpeg's concat demuxer and scaled/padded
+/// to the output canvas so mixed-resolution VODs join cleanly. `loop_forever`
+/// repeats the whole playlist (a 24-7 channel).
+pub async fn start_concat_playback(
+    state: Arc<AppState>,
+    source_id: Uuid,
+    files: &[std::path::PathBuf],
+    loop_forever: bool,
+    width: u32,
+    height: u32,
+    fps: u32,
+) -> Result<(), String> {
+    if files.is_empty() {
+        return Err("empty playlist".into());
+    }
+    let relay_tx = state.get_or_create_media_relay(source_id).await;
+
+    // Write a concat list file. Single quotes in paths are escaped per the
+    // concat demuxer's rules ( ' -> '\'' ).
+    let data_dir = state.config.read().await.data_dir.clone();
+    let _ = tokio::fs::create_dir_all(&data_dir).await;
+    let list_path = data_dir.join(format!("playlist_{}.txt", source_id));
+    let mut list = String::from("ffconcat version 1.0\n");
+    for f in files {
+        let p = f.to_string_lossy().replace('\'', "'\\''");
+        list.push_str(&format!("file '{}'\n", p));
+    }
+    tokio::fs::write(&list_path, list).await.map_err(|e| format!("write playlist: {}", e))?;
+
+    let vf = format!(
+        "scale={}:{}:force_original_aspect_ratio=decrease,pad={}:{}:(ow-iw)/2:(oh-ih)/2:black,setsar=1",
+        width, height, width, height
+    );
+    let mut args: Vec<String> = vec!["-hide_banner".into(), "-loglevel".into(), "warning".into()];
+    if loop_forever {
+        args.extend(["-stream_loop".into(), "-1".into()]);
+    }
+    args.extend([
+        "-re".into(), "-f".into(), "concat".into(), "-safe".into(), "0".into(),
+        "-i".into(), list_path.to_string_lossy().into_owned(),
+        "-vf".into(), vf,
+        "-c:v".into(), "libx264".into(), "-preset".into(), "veryfast".into(),
+        "-tune".into(), "zerolatency".into(), "-pix_fmt".into(), "yuv420p".into(),
+        "-g".into(), format!("{}", fps * 2), "-r".into(), format!("{}", fps), "-b:v".into(), "3000k".into(),
+        "-c:a".into(), "aac".into(), "-b:a".into(), "128k".into(), "-ar".into(), "48000".into(),
+        "-f".into(), "flv".into(), "pipe:1".into(),
+    ]);
+
+    tracing::info!("starting concat playback for {} ({} items, loop={})", source_id, files.len(), loop_forever);
+    let mut child = Command::new("ffmpeg")
+        .args(&args).stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped())
+        .kill_on_drop(true).spawn().map_err(|e| format!("failed to start ffmpeg: {}", e))?;
+    let stdout = child.stdout.take().ok_or("no stdout")?;
+    if let Some(stderr) = child.stderr.take() {
+        let sid = source_id;
+        tokio::spawn(async move {
+            let mut reader = tokio::io::BufReader::new(stderr);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut line).await {
+                    Ok(0) => break,
+                    Ok(_) => tracing::debug!("ffmpeg concat [{}]: {}", sid, line.trim()),
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+    {
+        let mut players = state.media_players.write().await;
+        if let Some(mut old) = players.remove(&source_id) { let _ = old.kill().await; }
+        players.insert(source_id, child);
+    }
+    let sc = state.clone();
+    tokio::spawn(async move { feed_relay(source_id, stdout, relay_tx, sc).await; });
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Build.** `cargo build -p muxshed-api` → Finished. (Confirm `feed_relay` is reachable from the new fn — it's a private fn in the same module, so a direct call works. Confirm `state.config.read().await.data_dir` is the right accessor by checking how other code reads `config`.)
+
+- [ ] **Step 3: Commit.**
+```bash
+git add crates/api/src/media_player.rs
+git commit -m "feat(schedules): concat playlist playback (seamless, loopable)"
+```
+
+---
+
+## Task 2: Playout controller — play the whole playlist
+
+**File:** `crates/api/src/playout.rs`
+
+- [ ] **Step 1: Replace single-VOD loading with the full ordered playlist.** Replace the `load_first_vod` function (and its call) so the controller loads ALL `vod` items in order plus the total duration. Add:
+
+```rust
+struct Playlist { files: Vec<std::path::PathBuf>, total_ms: u64 }
+
+async fn load_playlist(state: &AppState, schedule_id: Uuid) -> Result<Playlist, String> {
+    let rows = sqlx::query_as::<_, (String,)>(
+        "SELECT ref_id FROM schedule_items WHERE schedule_id = ? AND item_kind = 'vod' ORDER BY position ASC",
+    ).bind(schedule_id.to_string()).fetch_all(&state.db).await.map_err(|e| e.to_string())?;
+    if rows.is_empty() { return Err("schedule has no VOD items".into()); }
+    let mut files = Vec::new();
+    let mut total_ms = 0u64;
+    for (ref_id,) in rows {
+        let a = sqlx::query_as::<_, (String, i64)>("SELECT file_path, duration_ms FROM assets WHERE id = ?")
+            .bind(&ref_id).fetch_optional(&state.db).await.map_err(|e| e.to_string())?;
+        if let Some((path, dur)) = a { files.push(std::path::PathBuf::from(path)); total_ms += dur.max(0) as u64; }
+    }
+    if files.is_empty() { return Err("no playable VOD assets".into()); }
+    Ok(Playlist { files, total_ms })
+}
+```
+
+- [ ] **Step 2: Use it in `run_broadcast`.** In `run_broadcast`, replace the single-VOD block (the `load_first_vod` call, the `start_media_playback` call, and the `duration_ms`-based wait) with the playlist version:
+  - Load `let playlist = load_playlist(state, schedule_id).await?;` near the top (replacing `let vod = load_first_vod(...)`). Keep the existing `end_behavior`, `standby`, `destinations`, egress start, and standby routing exactly as they are.
+  - Where it currently starts the VOD, use the concat player and the output canvas from `cfg`:
+    ```rust
+    let vod_source = Uuid::new_v4();
+    let loop_forever = matches!(end_behavior, EndBehavior::Loop);
+    crate::media_player::start_concat_playback(
+        state.clone(), vod_source, &playlist.files, loop_forever, cfg.width, cfg.height, cfg.fps,
+    ).await.map_err(|e| format!("playlist playback: {}", e))?;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let _ = state.program_intent.send(Some(vod_source));
+    crate::egress_restart_for(state, vod_source).await;
+    ```
+  - The end wait: keep the existing structure but use the playlist total. When NOT looping:
+    ```rust
+    let dur = std::time::Duration::from_millis(playlist.total_ms.max(1000));
+    tokio::select! {
+        _ = tokio::time::sleep(dur) => {}
+        _ = wait_until_deactivated(state, schedule_id) => {
+            crate::media_player::stop_media_playback(state, &vod_source).await;
+            return Ok(());
+        }
+    }
+    crate::media_player::stop_media_playback(state, &vod_source).await;
+    // ... existing end_behavior match (Standby / Stop) unchanged, but where it referenced `vod_source` keep it ...
+    ```
+  - Remove the now-unused `VodItem`/`load_first_vod`/`load_standby_asset`'s VodItem if `load_standby_asset` still needs a file path: keep `load_standby_asset` (it returns a path for the standby); if it used the `VodItem` struct, change it to return `Option<std::path::PathBuf>` and adjust `ensure_standby` accordingly. Keep behavior identical.
+
+- [ ] **Step 3: Build + clippy.** `cargo build -p muxshed-api` (Finished) and `cargo clippy -p muxshed-api --all-targets -- -D warnings` (clean). Fix leftover unused items (delete `load_first_vod` / unused `VodItem` fields). Ensure `cargo test -p muxshed-api` still passes (the Phase-1 CRUD test is unaffected).
+
+- [ ] **Step 4: Commit.**
+```bash
+git add crates/api/src/playout.rs
+git commit -m "feat(schedules): playout plays the whole VOD playlist (loop = channel)"
+```
+
+---
+
+## Task 3: Frontend playlist editor
+
+**File:** `web/src/routes/(app)/schedules/+page.svelte`
+
+- [ ] **Step 1: Replace the single VOD `<select>` with a playlist editor.** In the `<script>`, replace `let vodId = $state('')` with a list plus an add-selector:
+```ts
+	let items = $state<string[]>([]);   // ordered VOD asset ids
+	let addVod = $state('');
+```
+In `newSchedule()`, set `items = []; addVod = assets[0]?.id ?? '';`. In `payload()`, change `items` to map the list: `items: items.map((ref_id) => ({ kind: 'vod', ref_id }))`. In `save()`, validate `if (items.length === 0) { notify.error('Add at least one VOD'); return; }` (replacing the `!vodId` check). When editing an existing schedule (if edit-load is added later), it's fine to leave `items` empty for now — Phase 1 create/edit already round-trips `items`.
+  Add helpers:
+```ts
+	function addItem() { if (addVod) items = [...items, addVod]; }
+	function removeItem(i: number) { items = items.filter((_, j) => j !== i); }
+	function move(i: number, d: -1 | 1) {
+		const j = i + d; if (j < 0 || j >= items.length) return;
+		const c = [...items]; [c[i], c[j]] = [c[j], c[i]]; items = c;
+	}
+	const assetName = (id: string) => assets.find((a) => a.id === id)?.name ?? id;
+```
+
+- [ ] **Step 2: Replace the VOD select markup** (the `<label for="s-vod">VOD</label>` + its `<select>`) with a playlist block:
+```svelte
+				<span class="field-label">Playlist</span>
+				<div class="mb-2 flex flex-col gap-1">
+					{#each items as id, i (id + i)}
+						<div class="row items-center justify-between text-xs">
+							<span class="text-amber">{i + 1}. {assetName(id)}</span>
+							<div class="flex gap-1">
+								<button type="button" class="btn btn--ghost" onclick={() => move(i, -1)} aria-label="Move up">▲</button>
+								<button type="button" class="btn btn--ghost" onclick={() => move(i, 1)} aria-label="Move down">▼</button>
+								<button type="button" class="btn btn--danger" onclick={() => removeItem(i)} aria-label="Remove">✕</button>
+							</div>
+						</div>
+					{/each}
+					{#if items.length === 0}<p class="text-[11px] text-amber-muted">No VODs yet.</p>{/if}
+				</div>
+				<div class="mb-3 flex gap-2">
+					<select bind:value={addVod} class="select flex-1">
+						{#each assets as a}<option value={a.id}>{a.name}</option>{/each}
+					</select>
+					<button type="button" class="btn" onclick={addItem}>+ Add</button>
+				</div>
+```
+Also update the "Loop" option help so it's clear loop = a 24-7 channel: leave the `end_behavior` select as is (stop / loop / standby).
+
+- [ ] **Step 3: Verify.** `cd web && npm run check` (0 errors) and `npm run build` (succeeds). Fix any type issues.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add "web/src/routes/(app)/schedules/+page.svelte"
+git commit -m "feat(schedules): playlist editor (multiple VODs, reorder)"
+```
+
+---
+
+## Task 4: End-to-end verification (controller-run, real ffmpeg)
+
+- [ ] **Step 1:** Create a script (mirroring `scratchpad/run_sched_e2e.sh` + the `nms/sink.js` persistent RTMP sink) that: starts the API on isolated ports; uploads **two distinct** short VODs (e.g. `testsrc2` and `smptebars`, ~4s each, visibly different); creates an RTMP destination → the sink; sets tz=UTC; creates a one-off schedule firing ~8s out whose **two** VOD items are both assets, `end_behavior: stop`. Wait through fire + playout.
+
+- [ ] **Step 2:** Assert: the scheduler fires; the sink records the broadcast; extract a frame from **early** and a frame from **late** in the recorded session and confirm they show **different** VODs (item 1 then item 2 aired in sequence — the playlist advanced seamlessly). Then run a second schedule with `end_behavior: loop` and confirm the stream keeps producing past the summed duration (channel loops). Capture frames as proof.
+
+- [ ] **Step 3:** Browser smoke test: open the Schedules editor, add two VODs to the playlist, reorder, save → confirm the DB has 2 `schedule_items` in the chosen order.
+
+- [ ] **Step 4:** Commit any fixes; run full `cargo test --workspace` + `clippy --all-targets` + `svelte-check`; open a PR "VOD scheduling — Phase 2 (playlists & channel)".
+
+---
+
+## Self-review
+
+- **Spec coverage:** multiple ordered VOD items via concat (T1/T2) · `loop` = 24-7 channel (T1/T2) · playlist editor (T3) · seamless-transition claim verified by the sequence e2e (T4). Scene/source items + run-history UI + cron builder remain for Phase 3.
+- **Type consistency:** `start_concat_playback(state, source_id, &[PathBuf], bool, u32,u32,u32)` used identically in T1 and T2; `Playlist { files, total_ms }` local to playout.
+- **Reuse:** T1 reuses `feed_relay` verbatim; T2 keeps the Phase-1 standby/egress/end structure, swapping only the source from single-VOD to concat.
+- **Executor notes:** confirm `state.config.read().await.data_dir`; delete `load_first_vod` + unused `VodItem` bits after T2; concat demuxer needs `-safe 0` for absolute paths; mixed-resolution handled by the `scale+pad` vf (reinit on resolution change).

--- a/web/src/routes/(app)/schedules/+page.svelte
+++ b/web/src/routes/(app)/schedules/+page.svelte
@@ -16,7 +16,8 @@
 	let triggerKind = $state<'once' | 'cron'>('cron');
 	let cron = $state('0 20 * * *');
 	let onceAt = $state('');
-	let vodId = $state('');
+	let items = $state<string[]>([]);
+	let addVod = $state('');
 	let standbyId = $state('');
 	let endBehavior = $state<'stop' | 'loop' | 'standby'>('stop');
 	let destIds = $state<string[]>([]);
@@ -41,7 +42,8 @@
 		triggerKind = 'cron';
 		cron = '0 20 * * *';
 		onceAt = '';
-		vodId = assets[0]?.id ?? '';
+		items = [];
+		addVod = assets[0]?.id ?? '';
 		standbyId = '';
 		endBehavior = 'stop';
 		destIds = [];
@@ -57,13 +59,28 @@
 			standby_asset_id: standbyId || null,
 			end_behavior: endBehavior,
 			until_at: null,
-			items: [{ kind: 'vod', ref_id: vodId }],
+			items: items.map((ref_id) => ({ kind: 'vod', ref_id })),
 		};
 	}
 
+	function addItem() {
+		if (addVod) items = [...items, addVod];
+	}
+	function removeItem(i: number) {
+		items = items.filter((_, j) => j !== i);
+	}
+	function move(i: number, d: -1 | 1) {
+		const j = i + d;
+		if (j < 0 || j >= items.length) return;
+		const c = [...items];
+		[c[i], c[j]] = [c[j], c[i]];
+		items = c;
+	}
+	const assetName = (id: string) => assets.find((a) => a.id === id)?.name ?? id;
+
 	async function save() {
-		if (!vodId) {
-			notify.error('Pick a VOD');
+		if (items.length === 0) {
+			notify.error('Add at least one VOD');
 			return;
 		}
 		try {
@@ -152,10 +169,26 @@
 				<label class="field-label" for="s-name">Name</label>
 				<input id="s-name" bind:value={name} class="input mb-3" />
 
-				<label class="field-label" for="s-vod">VOD</label>
-				<select id="s-vod" bind:value={vodId} class="select mb-3 w-full">
-					{#each assets as a}<option value={a.id}>{a.name}</option>{/each}
-				</select>
+				<span class="field-label">Playlist</span>
+				<div class="mb-2 flex flex-col gap-1">
+					{#each items as id, i (id + i)}
+						<div class="row items-center justify-between text-xs">
+							<span class="text-amber">{i + 1}. {assetName(id)}</span>
+							<div class="flex gap-1">
+								<button type="button" class="btn btn--ghost" onclick={() => move(i, -1)} aria-label="Move up">▲</button>
+								<button type="button" class="btn btn--ghost" onclick={() => move(i, 1)} aria-label="Move down">▼</button>
+								<button type="button" class="btn btn--danger" onclick={() => removeItem(i)} aria-label="Remove">✕</button>
+							</div>
+						</div>
+					{/each}
+					{#if items.length === 0}<p class="text-[11px] text-amber-muted">No VODs yet.</p>{/if}
+				</div>
+				<div class="mb-3 flex gap-2">
+					<select bind:value={addVod} class="select flex-1">
+						{#each assets as a}<option value={a.id}>{a.name}</option>{/each}
+					</select>
+					<button type="button" class="btn" onclick={addItem}>+ Add</button>
+				</div>
 
 				<label class="field-label" for="s-trigger">Trigger</label>
 				<select id="s-trigger" bind:value={triggerKind} class="select mb-2 w-full">

--- a/web/src/routes/(app)/schedules/+page.svelte
+++ b/web/src/routes/(app)/schedules/+page.svelte
@@ -51,6 +51,25 @@
 		destIds = [];
 	}
 
+	function editSchedule(s: Schedule) {
+		editing = s;
+		name = s.name;
+		if (s.trigger.kind === 'cron') {
+			triggerKind = 'cron';
+			cron = s.trigger.expr;
+			onceAt = '';
+		} else {
+			triggerKind = 'once';
+			onceAt = s.trigger.at.slice(0, 16);
+			cron = '0 20 * * *';
+		}
+		items = [...s.items].sort((a, b) => a.position - b.position).map((i) => i.ref_id);
+		addVod = assets[0]?.id ?? '';
+		standbyId = s.standby_asset_id ?? '';
+		endBehavior = s.end_behavior;
+		destIds = [...s.destination_ids];
+	}
+
 	function payload() {
 		const trigger = triggerKind === 'cron' ? { kind: 'cron', expr: cron } : { kind: 'once', at: onceAt };
 		return {
@@ -81,8 +100,11 @@
 	const assetName = (id: string) => assets.find((a) => a.id === id)?.name ?? id;
 
 	async function save() {
+		// Convenience: if a VOD is picked in the selector but not yet added to the
+		// playlist, add it on save so a single-VOD schedule doesn't need the extra click.
+		if (items.length === 0 && addVod) items = [addVod];
 		if (items.length === 0) {
-			notify.error('Add at least one VOD');
+			notify.error('Add at least one VOD to the playlist');
 			return;
 		}
 		try {
@@ -158,6 +180,7 @@
 				</div>
 				<div class="flex gap-1">
 					<button class="btn btn--ghost" onclick={() => runNow(s)}>Air now</button>
+					<button class="btn btn--ghost" onclick={() => editSchedule(s)}>Edit</button>
 					<button class="btn {s.enabled ? 'btn--go' : ''}" onclick={() => toggle(s)}>{s.enabled ? 'On' : 'Off'}</button>
 					<button class="btn btn--danger" onclick={() => del(s)}>✕</button>
 				</div>
@@ -168,6 +191,7 @@
 	{#if editing}
 		<div class="panel mt-4">
 			<div class="panel__body">
+				<h2 class="mb-3 text-amber-bright">{editing.id ? 'Edit schedule' : 'New schedule'}</h2>
 				<label class="field-label" for="s-name">Name</label>
 				<input id="s-name" bind:value={name} class="input mb-3" />
 

--- a/web/src/routes/(app)/schedules/+page.svelte
+++ b/web/src/routes/(app)/schedules/+page.svelte
@@ -8,6 +8,7 @@
 
 	let schedules = $state<Schedule[]>([]);
 	let assets = $state<Asset[]>([]);
+	let standbyAssets = $state<Asset[]>([]);
 	let destinations = $state<Destination[]>([]);
 	let tz = $state('UTC');
 
@@ -32,6 +33,7 @@
 		]);
 		schedules = s;
 		assets = a.filter((x) => x.asset_type === 'video');
+		standbyAssets = a.filter((x) => x.asset_type === 'image' || x.asset_type === 'video');
 		destinations = d;
 		tz = t.timezone;
 	}
@@ -211,7 +213,7 @@
 				<label class="field-label" for="s-standby">Standby card (optional)</label>
 				<select id="s-standby" bind:value={standbyId} class="select mb-3 w-full">
 					<option value="">— none —</option>
-					{#each assets as a}<option value={a.id}>{a.name}</option>{/each}
+					{#each standbyAssets as a}<option value={a.id}>{a.name}</option>{/each}
 				</select>
 
 				<span class="field-label">Destinations</span>


### PR DESCRIPTION
Follows Phase 1 (scheduled single-VOD premiere, #11). A schedule can now air an ordered list of VODs instead of just one, and setting the end behaviour to loop turns it into an always-on channel.

- `media_player.rs`: `start_concat_playback` plays a list of files as one stream via ffmpeg's concat demuxer, scaling and padding each to the output canvas so mixed-resolution VODs join without breaking. Loop uses `-stream_loop -1`. Reuses the existing FLV relay pump.
- `playout.rs`: loads the full ordered playlist and airs it, ending after the summed duration or looping. Standby/egress/end handling from Phase 1 is unchanged; the old single-VOD path is removed.
- `schedules/+page.svelte`: the VOD dropdown is now a playlist you can add to, remove from, and reorder. Also fixes the standby-card dropdown, which was filtering out images so it showed empty when you'd only uploaded stills.

Tested against a live API publishing to an RTMP sink: a two-item playlist aired in order, decoded clean end to end, and an 8s loop kept producing past its duration. `cargo test --workspace`, `clippy -D warnings`, `svelte-check`, and `npm run build` all pass.