### PR TITLE
Headless mode, management endpoints, and OpenAPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-scalar",
  "uuid",
  "webrtc",
 ]
@@ -1747,6 +1749,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "utoipa",
  "uuid",
 ]
 
@@ -3444,6 +3447,43 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+utoipa = { version = "5", features = ["axum_extras", "uuid", "chrono"] }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -206,8 +206,24 @@ All configuration is via environment variables. See `.env.example` for the full 
 | `MUXSHED_DB_PATH` | `muxshed.db` | SQLite database file path |
 | `MUXSHED_DATA_DIR` | `data` | Directory for recordings, stingers, etc. |
 | `MUXSHED_WEB_DIR` | *(none)* | Path to built frontend assets (set automatically in Docker) |
+| `MUXSHED_HEADLESS` | `false` | Run API-only, no web UI (see below) |
+| `MUXSHED_API_KEY` | *(none)* | Preseed an admin API key at startup (used in headless mode) |
 | `MUXSHED_LOG_LEVEL` | `info` | Log level: trace, debug, info, warn, error |
 | `RUST_LOG` | `info` | Rust log filter (overrides `MUXSHED_LOG_LEVEL` for fine-grained control) |
+
+## Headless Mode
+
+Run Muxshed API-only, with no web UI, for CLI or API workflows. Set
+`MUXSHED_HEADLESS=true` and preseed a key with `MUXSHED_API_KEY`. The full API is
+available; the root returns a JSON notice instead of the app. A slim image without
+the web build stage is at `docker/Dockerfile.headless`.
+
+```sh
+MUXSHED_HEADLESS=true MUXSHED_API_KEY=mxs_your_key ./target/release/muxshed-api
+```
+
+Interactive API docs are served on every instance at `/api/v1/docs` (Scalar), with the
+OpenAPI document at `/api/v1/openapi.json`.
 
 ## Running Tests
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -14,6 +14,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+utoipa = { workspace = true }
+utoipa-scalar = { version = "0.3", features = ["axum"] }
 cron = "0.12"
 chrono-tz = "0.9"
 thiserror = { workspace = true }

--- a/crates/api/src/auth.rs
+++ b/crates/api/src/auth.rs
@@ -75,6 +75,28 @@ fn validate_system_token(system_token_hash: &str, provided_key: &str) -> bool {
     hash == system_token_hash
 }
 
+/// Gate for the privileged `/admin` group. Requires `X-Management-Token` to match
+/// the configured management token (the portal-issued system token), and is
+/// entirely separate from tenant API-key auth, so tenant keys cannot reach it.
+pub async fn management_auth(
+    State(state): State<Arc<AppState>>,
+    req: Request<axum::body::Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let ok = req
+        .headers()
+        .get("X-Management-Token")
+        .and_then(|v| v.to_str().ok())
+        .zip(state.system_token.as_ref())
+        .map(|(provided, expected)| validate_system_token(expected, provided))
+        .unwrap_or(false);
+    if ok {
+        Ok(next.run(req).await)
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}
+
 fn extract_bearer_token(req: &Request<axum::body::Body>) -> Option<String> {
     req.headers()
         .get("Authorization")

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod auth;
 pub mod channel_hls;
+pub mod openapi;
 pub mod egress;
 pub mod failover;
 pub mod guest_webrtc;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -45,6 +45,7 @@ async fn run_migrations(db: &sqlx::SqlitePool) -> Result<(), Box<dyn std::error:
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = muxshed_api::routes::admin::START_TIME.set(std::time::Instant::now());
     let config = MuxshedConfig::from_env();
 
     tracing_subscriber::fmt()

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -71,11 +71,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute(&db)
         .await;
 
-    let needs_setup: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM api_keys")
+    // Headless bootstrap: seed the env-provided admin API key (idempotent) so an
+    // operator has a working credential without the web setup wizard.
+    if let Some(ref bootstrap) = config.bootstrap_api_key {
+        let hash = hash_key(bootstrap);
+        let scopes = serde_json::json!(["read", "control", "admin"]).to_string();
+        let res = sqlx::query(
+            "INSERT INTO api_keys (id, name, key_hash, scopes) \
+             SELECT ?, 'bootstrap', ?, ? \
+             WHERE NOT EXISTS (SELECT 1 FROM api_keys WHERE key_hash = ?)",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(&hash)
+        .bind(&scopes)
+        .bind(&hash)
+        .execute(&db)
+        .await?;
+        if res.rows_affected() > 0 {
+            tracing::info!("headless: seeded bootstrap API key from MUXSHED_API_KEY");
+        }
+    }
+
+    let key_count: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM api_keys")
         .fetch_one(&db)
         .await?;
-    if needs_setup == 0 {
-        tracing::info!("no API keys found — open the web UI to complete setup");
+    if key_count == 0 {
+        if config.headless {
+            tracing::warn!("headless: no API key configured — set MUXSHED_API_KEY to seed one");
+        } else {
+            tracing::info!("no API keys found — open the web UI to complete setup");
+        }
     }
 
     let (ws_tx, _) = broadcast::channel::<WsEvent>(256);
@@ -203,7 +228,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         start_rtmp_server(rtmp_state, rtmp_port).await;
     });
 
-    let app = routes::build_router(state.clone(), config.web_dir.clone());
+    let app = routes::build_router(state.clone(), config.web_dir.clone(), config.headless);
 
     let listener = tokio::net::TcpListener::bind(&config.listen_addr).await?;
     tracing::info!("listening on {}", config.listen_addr);

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -1,0 +1,139 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! OpenAPI document for the public API. Served as JSON at /api/v1/openapi.json
+//! with an interactive Scalar docs page at /api/v1/docs. The privileged /admin
+//! group is intentionally excluded from this document.
+
+use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
+use utoipa::{Modify, OpenApi};
+
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "api_key",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-API-Key"))),
+        );
+    }
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Muxshed API",
+        description = "REST API for the Muxshed self-hosted live production studio. Authenticate every request with the X-API-Key header."
+    ),
+    modifiers(&SecurityAddon),
+    security(("api_key" = [])),
+    paths(
+        crate::routes::status::get_status,
+        crate::routes::sources::list,
+        crate::routes::sources::create,
+        crate::routes::sources::create_from_asset,
+        crate::routes::sources::get_one,
+        crate::routes::sources::update,
+        crate::routes::sources::delete,
+        crate::routes::scenes::list,
+        crate::routes::scenes::create,
+        crate::routes::scenes::get_one,
+        crate::routes::scenes::update,
+        crate::routes::scenes::delete,
+        crate::routes::scenes::activate,
+        crate::routes::scenes::add_layer,
+        crate::routes::scenes::update_layer,
+        crate::routes::scenes::delete_layer,
+        crate::routes::destinations::list,
+        crate::routes::destinations::create,
+        crate::routes::destinations::update,
+        crate::routes::destinations::delete,
+        crate::routes::destinations::enable,
+        crate::routes::destinations::disable,
+        crate::routes::stream::start,
+        crate::routes::stream::stop,
+        crate::routes::recording::start,
+        crate::routes::recording::stop,
+        crate::routes::recording::status,
+        crate::routes::schedules::list,
+        crate::routes::schedules::create,
+        crate::routes::schedules::update,
+        crate::routes::schedules::delete,
+        crate::routes::schedules::run_now,
+        crate::routes::schedules::stop,
+        crate::routes::schedules::get_timezone,
+        crate::routes::schedules::set_timezone,
+        crate::routes::keys::list,
+        crate::routes::keys::create,
+        crate::routes::keys::delete,
+        crate::routes::channel::get_channel,
+        crate::routes::channel::update_channel,
+        crate::routes::channel::regenerate_token,
+        crate::routes::failover::get_config,
+        crate::routes::failover::set_config,
+        crate::routes::output::get_config,
+        crate::routes::output::set_config,
+        crate::routes::output::get_stats,
+    ),
+    components(schemas(
+        muxshed_common::Source,
+        muxshed_common::SourceKind,
+        muxshed_common::SourceState,
+        muxshed_common::Scene,
+        muxshed_common::Layer,
+        muxshed_common::LayerFit,
+        muxshed_common::Position,
+        muxshed_common::Size,
+        muxshed_common::Destination,
+        muxshed_common::DestinationKind,
+        muxshed_common::PipelineState,
+        muxshed_common::ApiKey,
+        muxshed_common::ApiScope,
+        muxshed_common::RecordingState,
+        muxshed_common::FailoverConfig,
+        muxshed_common::StingerConfig,
+        muxshed_common::StingerAudio,
+        muxshed_common::Schedule,
+        muxshed_common::ScheduleItem,
+        muxshed_common::ScheduleItemKind,
+        muxshed_common::ScheduleRun,
+        muxshed_common::TriggerKind,
+        muxshed_common::EndBehavior,
+        muxshed_common::ChannelConfig,
+        muxshed_common::ChannelInfo,
+        crate::routes::status::StatusResponse,
+        crate::routes::sources::CreateSource,
+        crate::routes::sources::UpdateSource,
+        crate::routes::sources::CreateFromAsset,
+        crate::routes::scenes::CreateScene,
+        crate::routes::scenes::UpdateScene,
+        crate::routes::scenes::CreateLayer,
+        crate::routes::scenes::UpdateLayer,
+        crate::routes::destinations::CreateDestination,
+        crate::routes::destinations::UpdateDestination,
+        crate::routes::recording::RecordingResponse,
+        crate::routes::schedules::CreateItem,
+        crate::routes::schedules::UpsertSchedule,
+        crate::routes::schedules::TzBody,
+        crate::routes::keys::CreateKey,
+        crate::routes::keys::KeyResponse,
+        crate::routes::keys::CreateKeyResponse,
+        crate::routes::channel::UpdateChannel,
+        crate::routes::output::OutputConfig,
+        crate::routes::output::OutputStats,
+    )),
+    tags(
+        (name = "status", description = "Pipeline status"),
+        (name = "sources", description = "Ingest sources"),
+        (name = "scenes", description = "Scenes and layers"),
+        (name = "destinations", description = "Fan-out destinations"),
+        (name = "stream", description = "Stream control"),
+        (name = "schedules", description = "Scheduled broadcasts"),
+        (name = "channel", description = "Public watch page"),
+        (name = "keys", description = "API keys"),
+        (name = "recording", description = "Local recording"),
+        (name = "overlays", description = "Overlays"),
+        (name = "failover", description = "Program failover")
+    )
+)]
+pub struct ApiDoc;

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -1,0 +1,166 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! Privileged management endpoints for the managed-hosting portal. Gated by the
+//! management token (see `crate::auth::management_auth`), separate from tenant API
+//! keys, and only mounted when a management token is configured. Not part of the
+//! public OpenAPI.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::Instant;
+
+use crate::state::AppState;
+use muxshed_common::SourceState;
+
+/// Process start time, set in `main` at startup, for uptime reporting.
+pub static START_TIME: OnceLock<Instant> = OnceLock::new();
+
+fn uptime_secs() -> u64 {
+    START_TIME.get().map(|s| s.elapsed().as_secs()).unwrap_or(0)
+}
+
+/// Best-effort process/system stats from /proc (Linux). Null on other platforms.
+fn system_stats() -> Value {
+    let rss_kb = std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1).and_then(|v| v.parse::<u64>().ok()))
+        });
+    let load_1m = std::fs::read_to_string("/proc/loadavg")
+        .ok()
+        .and_then(|s| s.split_whitespace().next().and_then(|v| v.parse::<f64>().ok()));
+    json!({ "process_rss_kb": rss_kb, "load_avg_1m": load_1m })
+}
+
+/// Health: version, uptime, pipeline state, headless flag.
+pub async fn health(State(state): State<Arc<AppState>>) -> Json<Value> {
+    let pipeline = serde_json::to_value(state.pipeline.state().await).ok();
+    let headless = state.config.read().await.headless;
+    Json(json!({
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+        "uptime_secs": uptime_secs(),
+        "pipeline": pipeline,
+        "headless": headless,
+    }))
+}
+
+/// Stats: sources, destinations, egress throughput, recording, and system load.
+pub async fn stats(State(state): State<Arc<AppState>>) -> Json<Value> {
+    let (total_sources, live_sources) = {
+        let s = state.source_states.read().await;
+        (
+            s.len(),
+            s.values().filter(|v| matches!(v, SourceState::Live)).count(),
+        )
+    };
+    let dest_total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM destinations")
+        .fetch_one(&state.db)
+        .await
+        .unwrap_or(0);
+    let dest_enabled: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM destinations WHERE enabled = 1")
+        .fetch_one(&state.db)
+        .await
+        .unwrap_or(0);
+    let egress = state.egress.stats().await;
+
+    Json(json!({
+        "sources": { "total": total_sources, "live": live_sources },
+        "destinations": { "total": dest_total, "enabled": dest_enabled },
+        "egress": {
+            "running": state.egress.is_running().await,
+            "bytes_sent": egress.bytes_sent,
+            "duration_secs": egress.duration_secs,
+            "source_bitrate_kbps": egress.source_bitrate_kbps,
+        },
+        "recording": serde_json::to_value(state.pipeline.recording_state().await).ok(),
+        "active_schedule": state.active_schedule.borrow().map(|id| id.to_string()),
+        "system": system_stats(),
+    }))
+}
+
+/// Connectivity: ingest ports, whether a source is live, program and egress state.
+pub async fn connectivity(State(state): State<Arc<AppState>>) -> Json<Value> {
+    let (rtmp_port, srt_start) = {
+        let c = state.config.read().await;
+        (c.rtmp_port, c.srt_port_range_start)
+    };
+    let source_live = {
+        let s = state.source_states.read().await;
+        s.values().any(|v| matches!(v, SourceState::Live))
+    };
+    Json(json!({
+        "rtmp_port": rtmp_port,
+        "srt_port_start": srt_start,
+        "source_live": source_live,
+        "program_on_air": state.program_source.borrow().is_some(),
+        "egress_running": state.egress.is_running().await,
+        "failover_active": *state.failover_active.borrow(),
+    }))
+}
+
+/// Restart: exit the process so the supervisor (Docker, systemd) restarts it.
+pub async fn restart() -> (StatusCode, Json<Value>) {
+    tracing::warn!("admin: restart requested; exiting for the supervisor to restart");
+    tokio::spawn(async {
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        std::process::exit(0);
+    });
+    (StatusCode::ACCEPTED, Json(json!({ "status": "restarting" })))
+}
+
+/// Read the effective (non-secret) config plus the stored settings.
+pub async fn get_config(State(state): State<Arc<AppState>>) -> Json<Value> {
+    let c = state.config.read().await;
+    let settings: Vec<(String, String)> = sqlx::query_as("SELECT key, value FROM settings")
+        .fetch_all(&state.db)
+        .await
+        .unwrap_or_default();
+    let settings_map: serde_json::Map<String, Value> = settings
+        .into_iter()
+        .map(|(k, v)| {
+            let parsed = serde_json::from_str(&v).unwrap_or(Value::String(v));
+            (k, parsed)
+        })
+        .collect();
+    Json(json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "headless": c.headless,
+        "listen_addr": c.listen_addr,
+        "rtmp_port": c.rtmp_port,
+        "srt_port_start": c.srt_port_range_start,
+        "data_dir": c.data_dir.display().to_string(),
+        "settings": settings_map,
+    }))
+}
+
+#[derive(serde::Deserialize)]
+pub struct ConfigUpdate {
+    pub settings: HashMap<String, Value>,
+}
+
+/// Push settings from the portal. Upserts each key into the settings table.
+pub async fn put_config(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<ConfigUpdate>,
+) -> Result<Json<Value>, StatusCode> {
+    for (k, v) in &body.settings {
+        let val = match v {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+            .bind(k)
+            .bind(&val)
+            .execute(&state.db)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(Json(json!({ "updated": body.settings.len() })))
+}

--- a/crates/api/src/routes/channel.rs
+++ b/crates/api/src/routes/channel.rs
@@ -78,6 +78,13 @@ async fn load_or_create(state: &AppState) -> Result<ChannelRow, ApiError> {
 
 // ── Authenticated handlers ───────────────────────────────────────────────────
 
+/// Get the public channel config.
+#[utoipa::path(
+    get,
+    path = "/api/v1/channel",
+    tag = "channel",
+    responses((status = 200, description = "Channel config", body = muxshed_common::ChannelConfig))
+)]
 pub async fn get_channel(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<ChannelConfig>, ApiError> {
@@ -85,13 +92,21 @@ pub async fn get_channel(
     Ok(Json(row_to_config(&row)))
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct UpdateChannel {
     pub enabled: Option<bool>,
     pub title: Option<String>,
     pub accent: Option<Option<String>>,
 }
 
+/// Update the public channel config.
+#[utoipa::path(
+    put,
+    path = "/api/v1/channel",
+    tag = "channel",
+    request_body = UpdateChannel,
+    responses((status = 200, description = "Updated channel config", body = muxshed_common::ChannelConfig))
+)]
 pub async fn update_channel(
     State(state): State<Arc<AppState>>,
     Json(body): Json<UpdateChannel>,
@@ -126,6 +141,13 @@ pub async fn update_channel(
     Ok(Json(row_to_config(&row)))
 }
 
+/// Regenerate the channel watch token.
+#[utoipa::path(
+    post,
+    path = "/api/v1/channel/regenerate-token",
+    tag = "channel",
+    responses((status = 200, description = "Channel config with new token", body = muxshed_common::ChannelConfig))
+)]
 pub async fn regenerate_token(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<ChannelConfig>, ApiError> {

--- a/crates/api/src/routes/destinations.rs
+++ b/crates/api/src/routes/destinations.rs
@@ -5,24 +5,32 @@ use axum::http::StatusCode;
 use axum::Json;
 use serde::Deserialize;
 use std::sync::Arc;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::error::ApiError;
 use crate::state::AppState;
 use muxshed_common::{Destination, DestinationKind, MuxshedError, WsEvent};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub struct CreateDestination {
     pub name: String,
     pub kind: DestinationKind,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub struct UpdateDestination {
     pub name: Option<String>,
     pub kind: Option<DestinationKind>,
 }
 
+/// List all destinations.
+#[utoipa::path(
+    get,
+    path = "/api/v1/destinations",
+    tag = "destinations",
+    responses((status = 200, description = "List of destinations", body = [muxshed_common::Destination]))
+)]
 pub async fn list(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<Destination>>, ApiError> {
@@ -34,6 +42,14 @@ pub async fn list(
     Ok(Json(dests))
 }
 
+/// Create a destination.
+#[utoipa::path(
+    post,
+    path = "/api/v1/destinations",
+    tag = "destinations",
+    request_body = CreateDestination,
+    responses((status = 201, description = "Destination created", body = muxshed_common::Destination))
+)]
 pub async fn create(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateDestination>,
@@ -59,6 +75,15 @@ pub async fn create(
     Ok((StatusCode::CREATED, Json(dest)))
 }
 
+/// Update a destination.
+#[utoipa::path(
+    put,
+    path = "/api/v1/destinations/{id}",
+    tag = "destinations",
+    params(("id" = String, Path, description = "Destination id")),
+    request_body = UpdateDestination,
+    responses((status = 200, description = "Destination updated", body = muxshed_common::Destination))
+)]
 pub async fn update(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -99,6 +124,14 @@ pub async fn update(
     Ok(Json(dest))
 }
 
+/// Delete a destination.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/destinations/{id}",
+    tag = "destinations",
+    params(("id" = String, Path, description = "Destination id")),
+    responses((status = 204, description = "Destination deleted"))
+)]
 pub async fn delete(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -115,6 +148,14 @@ pub async fn delete(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Enable a destination.
+#[utoipa::path(
+    post,
+    path = "/api/v1/destinations/{id}/enable",
+    tag = "destinations",
+    params(("id" = String, Path, description = "Destination id")),
+    responses((status = 200, description = "Destination enabled"))
+)]
 pub async fn enable(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -122,6 +163,14 @@ pub async fn enable(
     set_enabled(&state, &id, true).await
 }
 
+/// Disable a destination.
+#[utoipa::path(
+    post,
+    path = "/api/v1/destinations/{id}/disable",
+    tag = "destinations",
+    params(("id" = String, Path, description = "Destination id")),
+    responses((status = 200, description = "Destination disabled"))
+)]
 pub async fn disable(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,

--- a/crates/api/src/routes/failover.rs
+++ b/crates/api/src/routes/failover.rs
@@ -8,12 +8,27 @@ use crate::error::ApiError;
 use crate::state::AppState;
 use muxshed_common::{FailoverConfig, MuxshedError};
 
+/// Get the program failover config.
+#[utoipa::path(
+    get,
+    path = "/api/v1/failover",
+    tag = "failover",
+    responses((status = 200, description = "Failover config", body = muxshed_common::FailoverConfig))
+)]
 pub async fn get_config(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<FailoverConfig>, ApiError> {
     Ok(Json(crate::failover::load_config(&state).await))
 }
 
+/// Set the program failover config.
+#[utoipa::path(
+    put,
+    path = "/api/v1/failover",
+    tag = "failover",
+    request_body = muxshed_common::FailoverConfig,
+    responses((status = 200, description = "Updated failover config", body = muxshed_common::FailoverConfig))
+)]
 pub async fn set_config(
     State(state): State<Arc<AppState>>,
     Json(cfg): Json<FailoverConfig>,

--- a/crates/api/src/routes/keys.rs
+++ b/crates/api/src/routes/keys.rs
@@ -12,13 +12,13 @@ use crate::error::ApiError;
 use crate::state::AppState;
 use muxshed_common::MuxshedError;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct CreateKey {
     pub name: String,
     pub scopes: Vec<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct KeyResponse {
     pub id: String,
     pub name: String,
@@ -27,7 +27,7 @@ pub struct KeyResponse {
     pub last_used_at: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct CreateKeyResponse {
     pub id: String,
     pub name: String,
@@ -35,6 +35,13 @@ pub struct CreateKeyResponse {
     pub scopes: Vec<String>,
 }
 
+/// List API keys.
+#[utoipa::path(
+    get,
+    path = "/api/v1/keys",
+    tag = "keys",
+    responses((status = 200, description = "List of API keys", body = [KeyResponse]))
+)]
 pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<KeyResponse>>, ApiError> {
     let rows = sqlx::query_as::<_, KeyRow>(
         "SELECT id, name, scopes, created_at, last_used_at FROM api_keys",
@@ -56,6 +63,14 @@ pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<KeyResp
     Ok(Json(keys))
 }
 
+/// Create an API key.
+#[utoipa::path(
+    post,
+    path = "/api/v1/keys",
+    tag = "keys",
+    request_body = CreateKey,
+    responses((status = 201, description = "Created key (plaintext returned once)", body = CreateKeyResponse))
+)]
 pub async fn create(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateKey>,
@@ -85,6 +100,14 @@ pub async fn create(
     ))
 }
 
+/// Delete an API key.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/keys/{id}",
+    tag = "keys",
+    params(("id" = String, Path, description = "API key id")),
+    responses((status = 204, description = "Deleted"))
+)]
 pub async fn delete(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -26,14 +26,41 @@ mod ws;
 use crate::auth::auth_middleware;
 use crate::state::AppState;
 use axum::middleware;
+use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
-use axum::Router;
+use axum::{Json, Router};
 use std::sync::Arc;
 use axum::extract::DefaultBodyLimit;
+use axum::http::StatusCode;
 use tower_http::cors::CorsLayer;
 use tower_http::services::{ServeDir, ServeFile};
 
-pub fn build_router(state: Arc<AppState>, web_dir: Option<std::path::PathBuf>) -> Router {
+/// Root notice for headless instances (no web UI). Points at the API and docs.
+async fn headless_root() -> impl IntoResponse {
+    Json(serde_json::json!({
+        "service": "muxshed",
+        "version": env!("CARGO_PKG_VERSION"),
+        "headless": true,
+        "api": "/api/v1",
+        "docs": "/api/v1/docs"
+    }))
+}
+
+/// 404 for unmatched non-API routes in headless, with a pointer to the API.
+async fn headless_not_found() -> impl IntoResponse {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({
+            "error": { "code": "NOT_FOUND", "message": "no web UI in headless mode; use /api/v1" }
+        })),
+    )
+}
+
+pub fn build_router(
+    state: Arc<AppState>,
+    web_dir: Option<std::path::PathBuf>,
+    headless: bool,
+) -> Router {
     let api = Router::new()
         // Sources
         .route("/sources", get(sources::list).post(sources::create))
@@ -175,7 +202,11 @@ pub fn build_router(state: Arc<AppState>, web_dir: Option<std::path::PathBuf>) -
 
     let mut router = Router::new().nest("/api/v1", api);
 
-    if let Some(ref dir) = web_dir {
+    if headless {
+        // No web UI: a JSON notice at the root, JSON 404 for everything else.
+        router = router.route("/", get(headless_root)).fallback(headless_not_found);
+        tracing::info!("headless mode — web UI not served");
+    } else if let Some(ref dir) = web_dir {
         if dir.exists() {
             let index = dir.join("index.html");
             router = router.fallback_service(

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -4,20 +4,20 @@ pub mod admin;
 mod assets;
 mod audio;
 mod auth;
-mod failover;
+pub mod failover;
 mod broadcast;
-mod channel;
+pub mod channel;
 mod preview;
-mod destinations;
+pub mod destinations;
 mod guests;
-mod keys;
+pub mod keys;
 pub mod output;
-mod recording;
-mod scenes;
-mod schedules;
+pub mod recording;
+pub mod scenes;
+pub mod schedules;
 mod setup;
-mod sources;
-mod status;
+pub mod sources;
+pub mod status;
 mod stingers;
 pub mod stream;
 mod switching;
@@ -219,6 +219,25 @@ pub fn build_router(
     }
 
     let mut router = Router::new().nest("/api/v1", api);
+
+    // Public OpenAPI document and interactive Scalar docs, on every instance.
+    {
+        use utoipa::OpenApi;
+        use utoipa_scalar::{Scalar, Servable};
+        let spec = crate::openapi::ApiDoc::openapi();
+        router = router
+            .route(
+                "/api/v1/openapi.json",
+                get({
+                    let spec = spec.clone();
+                    move || {
+                        let spec = spec.clone();
+                        async move { Json(spec) }
+                    }
+                }),
+            )
+            .merge(Scalar::with_url("/api/v1/docs", spec));
+    }
 
     if headless {
         // No web UI: a JSON notice at the root, JSON 404 for everything else.

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -1,5 +1,6 @@
 // Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
 
+pub mod admin;
 mod assets;
 mod audio;
 mod auth;
@@ -61,7 +62,7 @@ pub fn build_router(
     web_dir: Option<std::path::PathBuf>,
     headless: bool,
 ) -> Router {
-    let api = Router::new()
+    let mut api = Router::new()
         // Sources
         .route("/sources", get(sources::list).post(sources::create))
         .route("/sources/from-asset", post(sources::create_from_asset))
@@ -199,6 +200,23 @@ pub fn build_router(
         // Public guest join (token-scoped — no auth)
         .route("/guest/{token}", get(guests::public_info))
         .route("/guest/{token}/whip", post(guests::whip));
+
+    // Privileged management group, only mounted when a management token is set.
+    // Gated by management_auth (X-Management-Token), separate from tenant keys.
+    if state.system_token.is_some() {
+        let admin_router = Router::new()
+            .route("/health", get(admin::health))
+            .route("/stats", get(admin::stats))
+            .route("/connectivity", get(admin::connectivity))
+            .route("/restart", post(admin::restart))
+            .route("/config", get(admin::get_config).put(admin::put_config))
+            .route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                crate::auth::management_auth,
+            ));
+        api = api.nest("/admin", admin_router);
+        tracing::info!("management endpoints enabled at /api/v1/admin");
+    }
 
     let mut router = Router::new().nest("/api/v1", api);
 

--- a/crates/api/src/routes/output.rs
+++ b/crates/api/src/routes/output.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::error::ApiError;
 use crate::state::AppState;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct OutputConfig {
     pub video_bitrate_kbps: u32,
     pub audio_bitrate_kbps: u32,
@@ -29,7 +29,7 @@ impl Default for OutputConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, utoipa::ToSchema)]
 pub struct OutputStats {
     pub bytes_sent: u64,
     pub duration_secs: f64,
@@ -42,6 +42,13 @@ pub struct OutputStats {
     pub source_encoder: Option<String>,
 }
 
+/// Get the encoder output config.
+#[utoipa::path(
+    get,
+    path = "/api/v1/output/config",
+    tag = "stream",
+    responses((status = 200, description = "Output config", body = OutputConfig))
+)]
 pub async fn get_config(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<OutputConfig>, ApiError> {
@@ -58,6 +65,14 @@ pub async fn get_config(
     Ok(Json(config))
 }
 
+/// Set the encoder output config.
+#[utoipa::path(
+    put,
+    path = "/api/v1/output/config",
+    tag = "stream",
+    request_body = OutputConfig,
+    responses((status = 200, description = "Updated output config", body = OutputConfig))
+)]
 pub async fn set_config(
     State(state): State<Arc<AppState>>,
     Json(config): Json<OutputConfig>,
@@ -73,6 +88,13 @@ pub async fn set_config(
     Ok(Json(config))
 }
 
+/// Get live output/egress stats.
+#[utoipa::path(
+    get,
+    path = "/api/v1/output/stats",
+    tag = "stream",
+    responses((status = 200, description = "Output stats", body = OutputStats))
+)]
 pub async fn get_stats(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<OutputStats>, ApiError> {

--- a/crates/api/src/routes/recording.rs
+++ b/crates/api/src/routes/recording.rs
@@ -4,12 +4,20 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
 use serde::Serialize;
+use utoipa::ToSchema;
 use std::sync::Arc;
 
 use crate::error::ApiError;
 use crate::state::AppState;
 use muxshed_common::{MuxshedError, PipelineState};
 
+/// Start recording the program output.
+#[utoipa::path(
+    post,
+    path = "/api/v1/record/start",
+    tag = "recording",
+    responses((status = 200, description = "Recording started"))
+)]
 pub async fn start(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
     let current = state.pipeline.state().await;
     if !matches!(current, PipelineState::Live { .. }) {
@@ -29,6 +37,13 @@ pub async fn start(State(state): State<Arc<AppState>>) -> Result<StatusCode, Api
     Ok(StatusCode::OK)
 }
 
+/// Stop the active recording.
+#[utoipa::path(
+    post,
+    path = "/api/v1/record/stop",
+    tag = "recording",
+    responses((status = 200, description = "Recording stopped"))
+)]
 pub async fn stop(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
     let rec = state.pipeline.recording_state().await;
     if !rec.recording {
@@ -40,13 +55,20 @@ pub async fn stop(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiE
     Ok(StatusCode::OK)
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct RecordingResponse {
     pub recording: bool,
     pub path: Option<String>,
     pub started_at: Option<String>,
 }
 
+/// Current recording status.
+#[utoipa::path(
+    get,
+    path = "/api/v1/record/status",
+    tag = "recording",
+    responses((status = 200, description = "Recording status", body = RecordingResponse))
+)]
 pub async fn status(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<RecordingResponse>, ApiError> {

--- a/crates/api/src/routes/scenes.rs
+++ b/crates/api/src/routes/scenes.rs
@@ -11,18 +11,18 @@ use crate::error::ApiError;
 use crate::state::AppState;
 use muxshed_common::{Layer, LayerFit, MuxshedError, Position, Scene, Size, WsEvent};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct CreateScene {
     pub name: String,
     pub layers: Option<Vec<CreateLayer>>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct UpdateScene {
     pub name: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct CreateLayer {
     pub source_id: Uuid,
     pub x: Option<i32>,
@@ -34,7 +34,7 @@ pub struct CreateLayer {
     pub fit: Option<LayerFit>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct UpdateLayer {
     pub source_id: Option<Uuid>,
     pub x: Option<i32>,
@@ -46,6 +46,13 @@ pub struct UpdateLayer {
     pub fit: Option<LayerFit>,
 }
 
+/// List all scenes.
+#[utoipa::path(
+    get,
+    path = "/api/v1/scenes",
+    tag = "scenes",
+    responses((status = 200, description = "Scenes", body = [muxshed_common::Scene]))
+)]
 pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<Scene>>, ApiError> {
     let scene_rows = sqlx::query_as::<_, SceneRow>("SELECT id, name FROM scenes")
         .fetch_all(&state.db)
@@ -64,6 +71,14 @@ pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<Scene>>
     Ok(Json(scenes))
 }
 
+/// Create a scene.
+#[utoipa::path(
+    post,
+    path = "/api/v1/scenes",
+    tag = "scenes",
+    request_body = CreateScene,
+    responses((status = 201, description = "Created scene", body = muxshed_common::Scene))
+)]
 pub async fn create(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateScene>,
@@ -94,6 +109,17 @@ pub async fn create(
     ))
 }
 
+/// Get a single scene by id.
+#[utoipa::path(
+    get,
+    path = "/api/v1/scenes/{id}",
+    tag = "scenes",
+    params(("id" = String, Path, description = "Scene id")),
+    responses(
+        (status = 200, description = "Scene", body = muxshed_common::Scene),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn get_one(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -113,6 +139,18 @@ pub async fn get_one(
     }))
 }
 
+/// Update a scene.
+#[utoipa::path(
+    put,
+    path = "/api/v1/scenes/{id}",
+    tag = "scenes",
+    params(("id" = String, Path, description = "Scene id")),
+    request_body = UpdateScene,
+    responses(
+        (status = 200, description = "Updated scene", body = muxshed_common::Scene),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn update(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -141,6 +179,17 @@ pub async fn update(
     }))
 }
 
+/// Delete a scene.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/scenes/{id}",
+    tag = "scenes",
+    params(("id" = String, Path, description = "Scene id")),
+    responses(
+        (status = 204, description = "Deleted"),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn delete(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -157,6 +206,17 @@ pub async fn delete(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Activate a scene (make it the live program).
+#[utoipa::path(
+    post,
+    path = "/api/v1/scenes/{id}/activate",
+    tag = "scenes",
+    params(("id" = String, Path, description = "Scene id")),
+    responses(
+        (status = 200, description = "Activated"),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn activate(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -195,6 +255,18 @@ async fn refresh_if_active(state: &Arc<AppState>, scene_id: &str) {
     }
 }
 
+/// Add a layer to a scene.
+#[utoipa::path(
+    post,
+    path = "/api/v1/scenes/{id}/layers",
+    tag = "scenes",
+    params(("id" = String, Path, description = "Scene id")),
+    request_body = CreateLayer,
+    responses(
+        (status = 201, description = "Created layer", body = muxshed_common::Layer),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn add_layer(
     State(state): State<Arc<AppState>>,
     Path(scene_id): Path<String>,
@@ -211,6 +283,21 @@ pub async fn add_layer(
     Ok((StatusCode::CREATED, Json(layer)))
 }
 
+/// Update a layer within a scene.
+#[utoipa::path(
+    put,
+    path = "/api/v1/scenes/{scene_id}/layers/{layer_id}",
+    tag = "scenes",
+    params(
+        ("scene_id" = String, Path, description = "Scene id"),
+        ("layer_id" = String, Path, description = "Layer id")
+    ),
+    request_body = UpdateLayer,
+    responses(
+        (status = 200, description = "Updated layer", body = muxshed_common::Layer),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn update_layer(
     State(state): State<Arc<AppState>>,
     Path((scene_id, layer_id)): Path<(String, String)>,
@@ -264,6 +351,20 @@ pub async fn update_layer(
     }))
 }
 
+/// Delete a layer from a scene.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/scenes/{scene_id}/layers/{layer_id}",
+    tag = "scenes",
+    params(
+        ("scene_id" = String, Path, description = "Scene id"),
+        ("layer_id" = String, Path, description = "Layer id")
+    ),
+    responses(
+        (status = 204, description = "Deleted"),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn delete_layer(
     State(state): State<Arc<AppState>>,
     Path((scene_id, layer_id)): Path<(String, String)>,

--- a/crates/api/src/routes/schedules.rs
+++ b/crates/api/src/routes/schedules.rs
@@ -13,10 +13,10 @@ use crate::schedule_time::{next_run_after, parse_tz};
 use crate::state::AppState;
 use muxshed_common::{EndBehavior, MuxshedError, Schedule, ScheduleItem, ScheduleItemKind, TriggerKind};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct CreateItem { pub kind: ScheduleItemKind, pub ref_id: Uuid }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct UpsertSchedule {
     pub name: String,
     #[serde(default = "yes")] pub enabled: bool,
@@ -64,6 +64,13 @@ fn trigger_cols(t: &TriggerKind) -> (&'static str, Option<String>, Option<String
     }
 }
 
+/// List schedules.
+#[utoipa::path(
+    get,
+    path = "/api/v1/schedules",
+    tag = "schedules",
+    responses((status = 200, description = "List of schedules", body = [muxshed_common::Schedule]))
+)]
 pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<Schedule>>, ApiError> {
     let ids = sqlx::query_as::<_, (String,)>("SELECT id FROM schedules ORDER BY created_at DESC")
         .fetch_all(&state.db).await?;
@@ -72,6 +79,14 @@ pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<Schedul
     Ok(Json(out))
 }
 
+/// Create a schedule.
+#[utoipa::path(
+    post,
+    path = "/api/v1/schedules",
+    tag = "schedules",
+    request_body = UpsertSchedule,
+    responses((status = 201, description = "Created", body = muxshed_common::Schedule))
+)]
 pub async fn create(
     State(state): State<Arc<AppState>>, Json(body): Json<UpsertSchedule>,
 ) -> Result<(StatusCode, Json<Schedule>), ApiError> {
@@ -96,6 +111,15 @@ pub async fn create(
     Ok((StatusCode::CREATED, Json(s)))
 }
 
+/// Update a schedule.
+#[utoipa::path(
+    put,
+    path = "/api/v1/schedules/{id}",
+    tag = "schedules",
+    params(("id" = String, Path, description = "Schedule id")),
+    request_body = UpsertSchedule,
+    responses((status = 200, description = "Updated", body = muxshed_common::Schedule))
+)]
 pub async fn update(
     State(state): State<Arc<AppState>>, Path(id): Path<String>, Json(body): Json<UpsertSchedule>,
 ) -> Result<Json<Schedule>, ApiError> {
@@ -116,6 +140,14 @@ pub async fn update(
     Ok(Json(load_schedule(&state, &id).await?.ok_or_else(|| MuxshedError::NotFound(id.clone()))?))
 }
 
+/// Delete a schedule.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/schedules/{id}",
+    tag = "schedules",
+    params(("id" = String, Path, description = "Schedule id")),
+    responses((status = 204, description = "Deleted"))
+)]
 pub async fn delete(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Result<StatusCode, ApiError> {
     let r = sqlx::query("DELETE FROM schedules WHERE id=?").bind(&id).execute(&state.db).await?;
     if r.rows_affected() == 0 { return Err(MuxshedError::NotFound(format!("schedule {id}")).into()); }
@@ -123,6 +155,14 @@ pub async fn delete(State(state): State<Arc<AppState>>, Path(id): Path<String>) 
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Run a schedule immediately.
+#[utoipa::path(
+    post,
+    path = "/api/v1/schedules/{id}/run",
+    tag = "schedules",
+    params(("id" = String, Path, description = "Schedule id")),
+    responses((status = 200, description = "Started"))
+)]
 pub async fn run_now(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Result<StatusCode, ApiError> {
     let sid: Uuid = id.parse().map_err(|_| MuxshedError::BadRequest("bad id".into()))?;
     if state.active_schedule.borrow().is_some() {
@@ -132,20 +172,42 @@ pub async fn run_now(State(state): State<Arc<AppState>>, Path(id): Path<String>)
     Ok(StatusCode::OK)
 }
 
+/// Stop the active broadcast.
+#[utoipa::path(
+    post,
+    path = "/api/v1/schedules/stop",
+    tag = "schedules",
+    responses((status = 200, description = "Stopped"))
+)]
 pub async fn stop(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
     crate::playout::stop_broadcast(&state).await;
     Ok(StatusCode::OK)
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct TzBody { pub timezone: String }
 
+/// Get the system timezone.
+#[utoipa::path(
+    get,
+    path = "/api/v1/settings/timezone",
+    tag = "schedules",
+    responses((status = 200, description = "Current timezone", body = TzBody))
+)]
 pub async fn get_timezone(State(state): State<Arc<AppState>>) -> Result<Json<serde_json::Value>, ApiError> {
     let tz = sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key='system_timezone'")
         .fetch_optional(&state.db).await?.map(|r| r.0).unwrap_or_else(|| "UTC".into());
     Ok(Json(serde_json::json!({ "timezone": tz })))
 }
 
+/// Set the system timezone.
+#[utoipa::path(
+    put,
+    path = "/api/v1/settings/timezone",
+    tag = "schedules",
+    request_body = TzBody,
+    responses((status = 200, description = "Updated timezone", body = TzBody))
+)]
 pub async fn set_timezone(State(state): State<Arc<AppState>>, Json(b): Json<TzBody>) -> Result<Json<serde_json::Value>, ApiError> {
     if b.timezone.parse::<chrono_tz::Tz>().is_err() {
         return Err(MuxshedError::BadRequest("unknown timezone".into()).into());

--- a/crates/api/src/routes/sources.rs
+++ b/crates/api/src/routes/sources.rs
@@ -13,18 +13,25 @@ use crate::state::AppState;
 use muxshed_common::{MuxshedError, Source, SourceKind, SourceState};
 use std::path::PathBuf;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct CreateSource {
     pub name: String,
     pub kind: SourceKind,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct UpdateSource {
     pub name: Option<String>,
     pub kind: Option<SourceKind>,
 }
 
+/// List all sources.
+#[utoipa::path(
+    get,
+    path = "/api/v1/sources",
+    tag = "sources",
+    responses((status = 200, description = "Sources", body = [muxshed_common::Source]))
+)]
 pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<Source>>, ApiError> {
     let rows = sqlx::query_as::<_, SourceRow>(
         "SELECT id, name, kind FROM sources WHERE kind NOT LIKE '%\"media_file\"%'"
@@ -46,6 +53,14 @@ pub async fn list(State(state): State<Arc<AppState>>) -> Result<Json<Vec<Source>
     Ok(Json(sources))
 }
 
+/// Create a source.
+#[utoipa::path(
+    post,
+    path = "/api/v1/sources",
+    tag = "sources",
+    request_body = CreateSource,
+    responses((status = 201, description = "Created source", body = muxshed_common::Source))
+)]
 pub async fn create(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateSource>,
@@ -99,6 +114,17 @@ pub async fn create(
     Ok((StatusCode::CREATED, Json(source)))
 }
 
+/// Get a single source by id.
+#[utoipa::path(
+    get,
+    path = "/api/v1/sources/{id}",
+    tag = "sources",
+    params(("id" = String, Path, description = "Source id")),
+    responses(
+        (status = 200, description = "Source", body = muxshed_common::Source),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn get_one(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -117,6 +143,18 @@ pub async fn get_one(
     Ok(Json(source))
 }
 
+/// Update a source.
+#[utoipa::path(
+    put,
+    path = "/api/v1/sources/{id}",
+    tag = "sources",
+    params(("id" = String, Path, description = "Source id")),
+    request_body = UpdateSource,
+    responses(
+        (status = 200, description = "Updated source", body = muxshed_common::Source),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn update(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -152,6 +190,17 @@ pub async fn update(
     Ok(Json(source))
 }
 
+/// Delete a source.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/sources/{id}",
+    tag = "sources",
+    params(("id" = String, Path, description = "Source id")),
+    responses(
+        (status = 204, description = "Deleted"),
+        (status = 404, description = "Not found")
+    )
+)]
 pub async fn delete(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -176,12 +225,20 @@ pub async fn delete(
     Ok(StatusCode::NO_CONTENT)
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct CreateFromAsset {
     pub asset_id: String,
     pub name: Option<String>,
 }
 
+/// Create a source from an existing media asset.
+#[utoipa::path(
+    post,
+    path = "/api/v1/sources/from-asset",
+    tag = "sources",
+    request_body = CreateFromAsset,
+    responses((status = 201, description = "Created source", body = muxshed_common::Source))
+)]
 pub async fn create_from_asset(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateFromAsset>,

--- a/crates/api/src/routes/status.rs
+++ b/crates/api/src/routes/status.rs
@@ -9,11 +9,18 @@ use crate::error::ApiError;
 use crate::state::AppState;
 use muxshed_common::PipelineState;
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct StatusResponse {
     pub pipeline: PipelineState,
 }
 
+/// Current pipeline status.
+#[utoipa::path(
+    get,
+    path = "/api/v1/status",
+    tag = "status",
+    responses((status = 200, description = "Pipeline status", body = StatusResponse))
+)]
 pub async fn get_status(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<StatusResponse>, ApiError> {

--- a/crates/api/src/routes/stream.rs
+++ b/crates/api/src/routes/stream.rs
@@ -11,6 +11,13 @@ use crate::routes::broadcast::BroadcastConfig;
 use crate::state::AppState;
 use muxshed_common::{Destination, DestinationKind, MuxshedError, PipelineState};
 
+/// Start the broadcast pipeline (go live).
+#[utoipa::path(
+    post,
+    path = "/api/v1/stream/start",
+    tag = "stream",
+    responses((status = 200, description = "Stream started"))
+)]
 pub async fn start(
     State(state): State<Arc<AppState>>,
     body: Option<Json<serde_json::Value>>,
@@ -149,6 +156,13 @@ pub async fn start(
     Ok(StatusCode::OK)
 }
 
+/// Stop the broadcast pipeline (end the stream).
+#[utoipa::path(
+    post,
+    path = "/api/v1/stream/stop",
+    tag = "stream",
+    responses((status = 200, description = "Stream stopped"))
+)]
 pub async fn stop(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
     let current = state.pipeline.state().await;
     if matches!(current, PipelineState::Idle) {

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -37,6 +37,8 @@ async fn setup() -> (axum::Router<()>, String, Arc<AppState>) {
         data_dir: PathBuf::from("/tmp/muxshed-test"),
         web_dir: None,
         log_level: "error".to_string(),
+        headless: false,
+        bootstrap_api_key: None,
     };
 
     let key = generate_api_key();
@@ -79,7 +81,7 @@ async fn setup() -> (axum::Router<()>, String, Arc<AppState>) {
         system_token: None,
     });
 
-    (build_router(state.clone(), None), key, state)
+    (build_router(state.clone(), None, false), key, state)
 }
 
 fn json_request(method: &str, uri: &str, key: &str, body: Option<&str>) -> Request<Body> {

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,6 +9,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+utoipa = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -11,6 +11,19 @@ pub struct MuxshedConfig {
     pub data_dir: PathBuf,
     pub web_dir: Option<PathBuf>,
     pub log_level: String,
+    /// Run without serving the web UI (API/CLI only). Set MUXSHED_HEADLESS=true.
+    pub headless: bool,
+    /// An admin API key preseeded from the environment (MUXSHED_API_KEY). In
+    /// headless mode this is how the operator gets their first credential without
+    /// the web setup wizard. Seeded (hashed) at startup, idempotently.
+    pub bootstrap_api_key: Option<String>,
+}
+
+fn env_bool(key: &str) -> bool {
+    matches!(
+        std::env::var(key).ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE") | Some("yes")
+    )
 }
 
 impl MuxshedConfig {
@@ -37,6 +50,8 @@ impl MuxshedConfig {
                 .map(PathBuf::from),
             log_level: std::env::var("MUXSHED_LOG_LEVEL")
                 .unwrap_or_else(|_| "info".to_string()),
+            headless: env_bool("MUXSHED_HEADLESS"),
+            bootstrap_api_key: std::env::var("MUXSHED_API_KEY").ok().filter(|s| !s.is_empty()),
         }
     }
 }

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Source {
     pub id: Uuid,
     pub name: String,
@@ -13,7 +13,7 @@ pub struct Source {
     pub state: SourceState,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SourceKind {
     Rtmp { stream_key: String },
@@ -22,13 +22,14 @@ pub enum SourceKind {
     TestPattern,
     MediaFile {
         asset_id: Uuid,
+        #[schema(value_type = String)]
         file_path: PathBuf,
         loop_mode: String,
     },
     Browser { url: String },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceState {
     Disconnected,
@@ -37,14 +38,14 @@ pub enum SourceState {
     Error(String),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Scene {
     pub id: Uuid,
     pub name: String,
     pub layers: Vec<Layer>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Layer {
     pub id: Uuid,
     pub source_id: Uuid,
@@ -57,7 +58,7 @@ pub struct Layer {
 }
 
 /// How a source fills its layer box.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LayerFit {
     /// Stretch to the box, ignoring aspect ratio.
@@ -88,22 +89,23 @@ impl LayerFit {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Position {
     pub x: i32,
     pub y: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Size {
     pub width: u32,
     pub height: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct StingerConfig {
     pub id: Uuid,
     pub name: String,
+    #[schema(value_type = String)]
     pub file_path: PathBuf,
     pub duration_ms: u64,
     pub start_ms: u64,
@@ -111,10 +113,11 @@ pub struct StingerConfig {
     pub clear_ms: u64,
     pub end_ms: u64,
     pub audio_behaviour: StingerAudio,
+    #[schema(value_type = String)]
     pub thumbnail_path: PathBuf,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum StingerAudio {
     Silent,
@@ -123,7 +126,7 @@ pub enum StingerAudio {
     Replace,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Destination {
     pub id: Uuid,
     pub name: String,
@@ -131,16 +134,19 @@ pub struct Destination {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum DestinationKind {
     Rtmp { url: String, stream_key: String },
     Rtmps { url: String, stream_key: String },
     Srt { url: String },
-    Recording { path: PathBuf },
+    Recording {
+        #[schema(value_type = String)]
+        path: PathBuf,
+    },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum PipelineState {
     Idle,
@@ -157,7 +163,7 @@ pub enum PipelineState {
     Error { message: String },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ApiKey {
     pub id: Uuid,
     pub name: String,
@@ -167,7 +173,7 @@ pub struct ApiKey {
     pub last_used_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ApiScope {
     Read,
@@ -176,9 +182,10 @@ pub enum ApiScope {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct RecordingState {
     pub recording: bool,
+    #[schema(value_type = Option<String>)]
     pub path: Option<PathBuf>,
     pub started_at: Option<DateTime<Utc>>,
 }
@@ -186,7 +193,7 @@ pub struct RecordingState {
 /// Program failover: when the live program output stops producing video, the
 /// program is automatically switched to a fallback source (a BRB image/video or
 /// a backup ingress) so destinations don't drop, then switched back on recovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct FailoverConfig {
     pub enabled: bool,
     /// Source shown while the program is offline. Any source: an image/video
@@ -210,7 +217,7 @@ impl Default for FailoverConfig {
 }
 
 /// How a broadcast ends when its content finishes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum EndBehavior {
     #[default]
@@ -228,7 +235,7 @@ impl EndBehavior {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ScheduleItemKind {
     Vod,
@@ -245,7 +252,7 @@ impl ScheduleItemKind {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TriggerKind {
     /// One-off local datetime in the system timezone, e.g. "2026-07-02T20:00:00".
@@ -254,7 +261,7 @@ pub enum TriggerKind {
     Cron { expr: String },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ScheduleItem {
     pub id: Uuid,
     pub position: u32,
@@ -262,7 +269,7 @@ pub struct ScheduleItem {
     pub ref_id: Uuid,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Schedule {
     pub id: Uuid,
     pub name: String,
@@ -277,7 +284,7 @@ pub struct Schedule {
     pub next_run_at: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ScheduleRun {
     pub id: Uuid,
     pub schedule_id: Uuid,
@@ -286,7 +293,7 @@ pub struct ScheduleRun {
     pub status: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ChannelConfig {
     pub enabled: bool,
     pub token: String,
@@ -297,7 +304,7 @@ pub struct ChannelConfig {
     pub watch_path: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ChannelInfo {
     pub title: String,
     pub logo_url: Option<String>,

--- a/docker/Dockerfile.headless
+++ b/docker/Dockerfile.headless
@@ -1,0 +1,66 @@
+# Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+# syntax=docker/dockerfile:1.7
+
+# Headless image: API only, no web UI. Drops the Node build stage entirely, so
+# the image is smaller and CI is faster. Run the API/CLI against /api/v1.
+
+# --- cargo-chef: pre-built image (skips cargo-chef compile) ---
+FROM lukemathwalker/cargo-chef:latest-rust-1.88 AS chef
+WORKDIR /build
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.toml
+COPY crates/ crates/
+RUN cargo chef prepare --recipe-path recipe.json
+
+# --- Rust builder ---
+FROM chef AS rust-builder
+
+COPY --from=planner /build/recipe.json recipe.json
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
+    CARGO_PROFILE_RELEASE_LTO=false \
+    cargo chef cook --release --recipe-path recipe.json
+
+COPY Cargo.toml Cargo.toml
+COPY crates/ crates/
+COPY migrations/ migrations/
+
+ENV SQLX_OFFLINE=true
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
+    CARGO_PROFILE_RELEASE_LTO=false \
+    cargo build --release && \
+    cp /build/target/release/muxshed-api /usr/local/bin/muxshed-api
+
+# --- Runtime ---
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=rust-builder /usr/local/bin/muxshed-api /usr/local/bin/
+
+ENV MUXSHED_DB_PATH=/config/muxshed.db
+ENV MUXSHED_DATA_DIR=/data
+ENV MUXSHED_LISTEN_ADDR=0.0.0.0:8080
+ENV MUXSHED_LOG_LEVEL=info
+ENV MUXSHED_HEADLESS=true
+ENV RUST_LOG=info
+
+EXPOSE 8080
+EXPOSE 1935
+EXPOSE 9000-9099/udp
+
+VOLUME /config
+VOLUME /data
+
+CMD ["/usr/local/bin/muxshed-api"]

--- a/docs/superpowers/specs/2026-07-03-headless-mode-design.md
+++ b/docs/superpowers/specs/2026-07-03-headless-mode-design.md
@@ -1,0 +1,112 @@
+# Headless Mode, Comprehensive API, Management Endpoints, and OpenAPI — Design
+
+## Goal
+
+Run Muxshed with no UI, for people who drive it from a CLI or the API. In headless mode the
+API must be comprehensive (everything the UI can do is reachable over the API), efficient
+(no wasted work serving a UI nobody loads), and expose a separate set of privileged
+management endpoints for the managed-hosting portal. Ship an OpenAPI document with an
+interactive docs page on every instance.
+
+## Context
+
+The system is already API-first. The Rust/Axum API (`crates/api`) is the whole engine; the
+SvelteKit UI is a static bundle the API serves from `MUXSHED_WEB_DIR`. Headless is therefore
+additive, not a re-architecture: one binary, one API, the UI optional on top. This design
+does not split the API into a separate service.
+
+## Decisions (agreed with the owner)
+
+- Headless is a flag on the same binary and image: `MUXSHED_HEADLESS=true`.
+- The first API key is provided by the environment at setup time.
+- Management uses a dedicated token, separate from tenant keys. Each machine is single tenant.
+- Deliver the API plus OpenAPI. No first-party CLI in this work.
+- The `/admin` surface covers health, stats, connectivity, restart, and config.
+- The OpenAPI docs page is public on every instance.
+
+## Design
+
+### 1. Headless flag
+
+- Add `headless: bool` to `MuxshedConfig`, read from `MUXSHED_HEADLESS`.
+- When true, the router does not mount the static-file and SPA-fallback layer. All
+  `/api/v1/*` routes are unchanged. Unmatched non-API routes return a JSON 404, and `GET /`
+  returns a small JSON notice with the version and a link to `/api/v1/docs`.
+- `MUXSHED_WEB_DIR` is ignored in headless.
+
+### 2. First key from the environment
+
+- Add `bootstrap_api_key: Option<String>` from `MUXSHED_API_KEY`.
+- On startup, if it is set, upsert an API key row with that exact value (SHA-256 hashed,
+  `Admin` scope, name "bootstrap") and mark setup complete. It is idempotent: re-seeding the
+  same value on restart is a no-op.
+- This bypasses the web setup wizard. The web admin user is not created in headless. If the
+  UI is later enabled on the instance, the normal setup flow still works.
+- `GET /api/v1/setup/status` reports complete once a key exists.
+- The portal generates a strong key and sets it at provision time, so it already knows the
+  credential. The key is stored hashed and never logged.
+
+### 3. Management endpoints
+
+- Add `management_token: Option<String>` from `MUXSHED_MANAGEMENT_TOKEN`.
+- A new `management_auth` middleware checks the `X-Management-Token` header with a
+  constant-time comparison against the configured token. If no token is configured, the
+  `/admin` group is not mounted at all, so self-hosters without a portal have no admin
+  surface to attack.
+- Route group `/api/v1/admin`, gated by `management_auth`, entirely separate from the tenant
+  `auth` middleware so tenant API keys cannot reach it:
+  - `GET /admin/health` — version, uptime, pipeline state, headless flag.
+  - `GET /admin/stats` — active streams, source and destination states, bytes and bitrate in
+    and out, CPU and memory.
+  - `GET /admin/connectivity` — RTMP and SRT listeners bound, destination reachability from
+    the last egress state, whether a source is live.
+  - `POST /admin/restart` — graceful shutdown for the supervisor to restart, or an in-process
+    reload where possible.
+  - `GET /admin/config` and `PUT /admin/config` — read and push the mutable subset of
+    instance config.
+- The `/admin` group is excluded from the public OpenAPI (see section 4).
+
+### 4. OpenAPI
+
+- Add `utoipa` and `utoipa-scalar` to `crates/api`.
+- Derive `ToSchema` on the shared types in `crates/common`, and annotate handlers with
+  `#[utoipa::path(...)]`.
+- Build the `OpenApi` document and serve `GET /api/v1/openapi.json` plus an interactive docs
+  page at `GET /api/v1/docs` rendered with Scalar. Public on every instance.
+- The public spec documents tenant endpoints only. The `/admin` group is described in a
+  separate internal document at `GET /api/v1/admin/openapi.json`, gated by the management
+  token, for the portal.
+- Security scheme on the public spec: `X-API-Key` as an apiKey header.
+
+### 5. Efficiency
+
+- Headless skips static serving.
+- Add `docker/Dockerfile.headless`: a single Rust build stage plus the ffmpeg runtime, with
+  no Node build stage. Smaller image and faster CI. The default UI image and compose files
+  are unchanged.
+
+## Non-goals
+
+- No separate headless service or second API. One API, UI optional.
+- No first-party CLI in this work. The OpenAPI spec makes one straightforward later.
+- No change to the media pipeline.
+
+## Testing
+
+- Headless boot: with `MUXSHED_HEADLESS=true` and `MUXSHED_API_KEY` set, the key
+  authenticates, `/` returns the JSON notice, a static asset path returns 404, and a core API
+  flow (create a source, list sources) works.
+- Bootstrap: the env key seeds a working credential, setup-status reports complete, and a
+  wrong key is rejected. Re-seeding the same key on restart does not duplicate rows.
+- Management: `/admin/*` requires the management token, a tenant API key is rejected, each
+  endpoint returns the expected shape, and the `/admin` group is absent when no management
+  token is configured.
+- OpenAPI: `/openapi.json` is valid, `/docs` renders, every annotated route appears, and the
+  `/admin` group is excluded from the public spec.
+
+## Phasing (each phase is shippable on its own)
+
+1. Headless flag, env-key bootstrap, slim headless image.
+2. Management token, `management_auth`, and the `/admin` endpoints for the portal.
+3. utoipa OpenAPI plus the Scalar docs page over the public API, and an audit of every UI
+   action to confirm it has an endpoint, filling any gaps found.


### PR DESCRIPTION
Implements the headless-mode design in three phases. Runs Muxshed API-only for CLI and API users, adds privileged management endpoints for the portal, and ships an OpenAPI document with interactive docs.

## Phase 1: headless
- `MUXSHED_HEADLESS=true` skips serving the web UI. The root returns a JSON notice, non-API paths return a JSON 404, and `MUXSHED_WEB_DIR` is ignored.
- `MUXSHED_API_KEY` preseeds an admin key at startup (idempotent), so a headless operator gets a credential without the web wizard.
- `docker/Dockerfile.headless`: no Node build stage, smaller image.

## Phase 2: management endpoints
- `/api/v1/admin` gated by `management_auth` (`X-Management-Token` against the portal-issued `MUXSHED_SYSTEM_TOKEN`), separate from tenant keys and only mounted when the token is set.
- Endpoints: health, stats, connectivity, restart, and config get/put. Excluded from the public OpenAPI.

## Phase 3: OpenAPI
- utoipa across the public API: domain types derive ToSchema, handlers are annotated, and the document is served at `/api/v1/openapi.json` with a Scalar page at `/api/v1/docs`, public on every instance. 30 paths, 46 operations, 45 schemas.
- API-completeness audit: every studio action the web UI performs maps to an endpoint. (The web client's `/instances/*` methods have no backing and are a portal concept, flagged for cleanup.)

Verified end to end for each phase: headless boot and bootstrap-key auth, the `/` notice and non-API 404, the management auth separation and every admin endpoint, `/admin` absent without a token, and the served spec plus Scalar docs. `cargo test --workspace` and `clippy` pass.