### PR TITLE
Output config popup, applied live (v1.7.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-api"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-common"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-processor"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.7.0"
+version = "1.7.1"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/crates/api/src/egress.rs
+++ b/crates/api/src/egress.rs
@@ -64,6 +64,15 @@ impl EgressManager {
             .await;
     }
 
+    /// Update the output config used on the next restart. Used to apply an
+    /// output-config change (resolution, bitrate) to a live stream: set it, then
+    /// call `restart` so the encoder comes back with the new settings.
+    pub async fn set_output_config(&self, cfg: Option<crate::routes::output::OutputConfig>) {
+        if let Some(params) = self.restart_params.lock().await.as_mut() {
+            params.2 = cfg;
+        }
+    }
+
     pub async fn start(
         &self,
         _source_id: Uuid,

--- a/crates/api/src/routes/output.rs
+++ b/crates/api/src/routes/output.rs
@@ -75,8 +75,15 @@ pub async fn get_config(
 )]
 pub async fn set_config(
     State(state): State<Arc<AppState>>,
-    Json(config): Json<OutputConfig>,
+    Json(mut config): Json<OutputConfig>,
 ) -> Result<Json<OutputConfig>, ApiError> {
+    // Clamp defensively so a bad value can't wedge the encoder.
+    config.width = config.width.clamp(160, 3840);
+    config.height = config.height.clamp(120, 2160);
+    config.fps = config.fps.clamp(1, 60);
+    config.video_bitrate_kbps = config.video_bitrate_kbps.clamp(500, 20000);
+    config.audio_bitrate_kbps = config.audio_bitrate_kbps.clamp(32, 320);
+
     let json = serde_json::to_string(&config)
         .map_err(|e| muxshed_common::MuxshedError::Internal(e.to_string()))?;
 
@@ -84,6 +91,21 @@ pub async fn set_config(
         .bind(&json)
         .execute(&state.db)
         .await?;
+
+    // Apply immediately if a stream is live: restart the egress and the watch-page
+    // encoder with the new config (a brief destination reconnect, like failover).
+    let live = !matches!(
+        state.pipeline.state().await,
+        muxshed_common::PipelineState::Idle | muxshed_common::PipelineState::Stopping
+    );
+    if live {
+        state.egress.set_output_config(Some(config.clone())).await;
+        let program_src = *state.program_source.borrow();
+        if let Some(src) = program_src {
+            crate::egress_restart_for(&state, src).await;
+        }
+        crate::routes::stream::ensure_channel_hls(&state).await;
+    }
 
     Ok(Json(config))
 }

--- a/web/src/routes/(app)/+page.svelte
+++ b/web/src/routes/(app)/+page.svelte
@@ -18,7 +18,26 @@
 	import { popout } from '$lib/popout';
 	import PopoutButton from '../../components/PopoutButton.svelte';
 	import { Checkbox } from '$lib/components/ui/checkbox';
+	import Dialog from '$lib/components/ui/dialog/Dialog.svelte';
 	import { notify } from '$lib/notify';
+
+	// Output config popup
+	let showOutput = $state(false);
+	let draft = $state<OutputConfig>({
+		video_bitrate_kbps: 4500,
+		audio_bitrate_kbps: 160,
+		width: 1920,
+		height: 1080,
+		fps: 30,
+	});
+	let resSelect = $state('1080p');
+	const RES_PRESETS = [
+		{ label: '2160p', w: 3840, h: 2160 },
+		{ label: '1440p', w: 2560, h: 1440 },
+		{ label: '1080p', w: 1920, h: 1080 },
+		{ label: '720p', w: 1280, h: 720 },
+		{ label: '480p', w: 854, h: 480 },
+	];
 
 	let stingers = $state<StingerConfig[]>([]);
 	let assets = $state<Asset[]>([]);
@@ -220,6 +239,31 @@
 		}
 	}
 
+	function openOutput() {
+		draft = { ...outputConfig };
+		const m = RES_PRESETS.find((p) => p.w === draft.width && p.h === draft.height);
+		resSelect = m ? m.label : 'custom';
+		showOutput = true;
+	}
+
+	function onResChange() {
+		const p = RES_PRESETS.find((x) => x.label === resSelect);
+		if (p) {
+			draft.width = p.w;
+			draft.height = p.h;
+		}
+	}
+
+	async function saveOutput() {
+		try {
+			outputConfig = await api.setOutputConfig(draft);
+			showOutput = false;
+			notify.success($isLive ? 'Output config applied' : 'Output config saved');
+		} catch (e) {
+			notify.error(e);
+		}
+	}
+
 	function formatBytes(bytes: number): string {
 		if (bytes < 1024) return `${bytes} B`;
 		if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -375,7 +419,15 @@
 		<div class="mb-4 grid grid-cols-2 gap-4">
 			<!-- Config (under Program) -->
 			<section class="panel">
-				<header class="panel__head">▮ OUTPUT CONFIG</header>
+				<header class="panel__head flex items-center justify-between">
+					<span>▮ OUTPUT CONFIG</span>
+					<button
+						onclick={openOutput}
+						class="btn btn--ghost"
+						style="min-height:20px;padding:1px 8px;font-size:11px"
+						aria-label="Edit output config">Edit</button
+					>
+				</header>
 				<div class="panel__body space-y-1">
 					<div class="flex justify-between">
 						<span class="text-amber-dim">Resolution</span>
@@ -653,3 +705,56 @@
 				</div>
 			</section>
 </div>
+
+<Dialog bind:open={showOutput}>
+	<div class="panel w-[380px] max-w-[90vw]">
+		<header class="panel__head flex items-center justify-between">
+			<span>▮ OUTPUT CONFIG</span>
+			<button onclick={() => (showOutput = false)} class="text-amber-muted hover:text-amber-bright" aria-label="Close">✕</button>
+		</header>
+		<div class="panel__body space-y-3">
+			{#if $isLive}
+				<p class="text-[11px] text-amber-bright">You are live. Saving will briefly reconnect your destinations.</p>
+			{/if}
+			<div>
+				<label class="field-label" for="oc-res">Resolution</label>
+				<select id="oc-res" bind:value={resSelect} onchange={onResChange} class="select w-full">
+					{#each RES_PRESETS as p}<option value={p.label}>{p.label} ({p.w}x{p.h})</option>{/each}
+					<option value="custom">Custom</option>
+				</select>
+			</div>
+			{#if resSelect === 'custom'}
+				<div class="grid grid-cols-2 gap-2">
+					<div>
+						<label class="field-label" for="oc-w">Width</label>
+						<input id="oc-w" type="number" min="160" max="3840" bind:value={draft.width} class="input" />
+					</div>
+					<div>
+						<label class="field-label" for="oc-h">Height</label>
+						<input id="oc-h" type="number" min="120" max="2160" bind:value={draft.height} class="input" />
+					</div>
+				</div>
+			{/if}
+			<div>
+				<label class="field-label" for="oc-fps">Frame rate</label>
+				<select id="oc-fps" bind:value={draft.fps} class="select w-full">
+					{#each [24, 25, 30, 50, 60] as f}<option value={f}>{f} fps</option>{/each}
+				</select>
+			</div>
+			<div>
+				<label class="field-label" for="oc-vb">Video bitrate (kbps)</label>
+				<input id="oc-vb" type="number" min="500" max="20000" step="100" bind:value={draft.video_bitrate_kbps} class="input" />
+			</div>
+			<div>
+				<label class="field-label" for="oc-ab">Audio bitrate (kbps)</label>
+				<select id="oc-ab" bind:value={draft.audio_bitrate_kbps} class="select w-full">
+					{#each [96, 128, 160, 192, 256] as a}<option value={a}>{a} kbps</option>{/each}
+				</select>
+			</div>
+			<div class="flex gap-2 pt-1">
+				<button onclick={saveOutput} class="btn btn--go">Save</button>
+				<button onclick={() => (showOutput = false)} class="btn btn--ghost">Cancel</button>
+			</div>
+		</div>
+	</div>
+</Dialog>


### PR DESCRIPTION
Adds an Output config popup to the studio screen and applies changes to a live stream immediately.

- An Edit button on the Output panel opens a modal to set resolution (presets 2160p/1440p/1080p/720p/480p or custom), frame rate, video bitrate and audio bitrate.
- Save persists as before. When a stream is live, the backend also restarts the egress and the watch-page encoder with the new config so it takes effect at once (a brief destination reconnect, the same as failover). When idle, it applies on next go-live.
- The backend clamps values defensively.

Verified: idle save clamps out-of-range values and persists; changing config mid-broadcast restarts the egress at the new resolution (confirmed 1920x1080 to 1280x720 from the egress encoder's own output); the popup opens, presets work, and save round-trips through the UI. Bumps to 1.7.1.