### PR TITLE
Accept all H.264 profiles for WHIP ingest (v1.8.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-api"
-version = "1.8.4"
+version = "1.8.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-common"
-version = "1.8.4"
+version = "1.8.5"
 dependencies = [
  "chrono",
  "serde",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-processor"
-version = "1.8.4"
+version = "1.8.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.4"
+version = "1.8.5"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/crates/api/src/webrtc_ingest.rs
+++ b/crates/api/src/webrtc_ingest.rs
@@ -372,22 +372,35 @@ async fn build_peer(state: &AppState) -> Result<Arc<RTCPeerConnection>, String> 
         RTPCodecType::Video,
     )
     .map_err(|e| format!("register vp8: {}", e))?;
-    m.register_codec(
-        RTCRtpCodecParameters {
-            capability: RTCRtpCodecCapability {
-                mime_type: MIME_TYPE_H264.to_owned(),
-                clock_rate: 90000,
-                channels: 0,
-                sdp_fmtp_line: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f"
-                    .to_owned(),
-                rtcp_feedback: vec![],
+    // webrtc-rs matches an H.264 offer strictly by its profile-level-id, so a
+    // single registered variant rejects encoders that use a different profile
+    // (OBS commonly offers High profile). Register the same broad set of H.264
+    // profile/packetization variants webrtc-rs uses by default, which matches
+    // Chrome, Firefox, Safari, and OBS. Whatever profile is negotiated, the pump
+    // reads the track's mime as H.264 and forwards it the same way.
+    for (pt, fmtp) in [
+        (102u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f"),
+        (127u8, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f"),
+        (125u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f"),
+        (108u8, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f"),
+        (123u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032"),
+    ] {
+        m.register_codec(
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_H264.to_owned(),
+                    clock_rate: 90000,
+                    channels: 0,
+                    sdp_fmtp_line: fmtp.to_owned(),
+                    rtcp_feedback: vec![],
+                },
+                payload_type: pt,
+                ..Default::default()
             },
-            payload_type: 102,
-            ..Default::default()
-        },
-        RTPCodecType::Video,
-    )
-    .map_err(|e| format!("register h264: {}", e))?;
+            RTPCodecType::Video,
+        )
+        .map_err(|e| format!("register h264 {}: {}", pt, e))?;
+    }
     m.register_codec(
         RTCRtpCodecParameters {
             capability: RTCRtpCodecCapability {


### PR DESCRIPTION
A WHIP publisher whose H.264 profile did not exactly match our single registered variant (profile-level-id 42e01f) was rejected by webrtc-rs with "codec not found". The video track then delivered no packets, so the source never went live even though the encoder showed connected. OBS commonly offers High profile, which is why it failed in practice while the baseline test passed.

Register the same broad set of H.264 profile and packetization variants webrtc-rs uses by default, so Chrome, Firefox, Safari, and OBS all match. The pump still detects the negotiated codec off the track, so forwarding is unchanged.

Reproduced with a High-profile ffmpeg WHIP publish: the source fails to go live before this change, and goes live and reaches an RTMP destination after.