### PR TITLE
Default WebRTC ICE to no servers instead of public STUN (v1.8.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-api"
-version = "1.8.5"
+version = "1.8.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-common"
-version = "1.8.5"
+version = "1.8.6"
 dependencies = [
  "chrono",
  "serde",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-processor"
-version = "1.8.5"
+version = "1.8.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.5"
+version = "1.8.6"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/crates/api/src/routes/webrtc_config.rs
+++ b/crates/api/src/routes/webrtc_config.rs
@@ -24,24 +24,17 @@ pub struct IceServer {
     pub credential: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// The default is no ICE servers. The primary self-host case is an encoder on
+/// the same LAN as the server, which connects with host candidates alone, so an
+/// empty default keeps offline and air-gapped installs working with no external
+/// dependency. Add STUN or TURN under the WebRTC settings to publish or guest
+/// across NAT.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WebrtcConfig {
     pub ice_servers: Vec<IceServer>,
 }
 
-impl Default for WebrtcConfig {
-    fn default() -> Self {
-        Self {
-            ice_servers: vec![IceServer {
-                urls: vec!["stun:stun.l.google.com:19302".to_string()],
-                username: None,
-                credential: None,
-            }],
-        }
-    }
-}
-
-/// Load the configured ICE servers, falling back to the STUN default.
+/// Load the configured ICE servers, falling back to an empty (host-candidate) set.
 pub async fn load(state: &AppState) -> WebrtcConfig {
     sqlx::query_as::<_, (String,)>("SELECT value FROM settings WHERE key = 'webrtc_config'")
         .fetch_optional(&state.db)

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -625,9 +625,9 @@ async fn test_guest_public_info() {
     let info = response_json(resp).await;
     assert_eq!(info["name"], "Sam");
     assert_eq!(info["status"], "invited");
-    // The join page receives ICE servers matching the server peer.
+    // The join page receives the configured ICE servers (empty by default; the
+    // browser falls back to its own STUN for remote guests).
     assert!(info["ice_servers"].is_array());
-    assert!(!info["ice_servers"].as_array().unwrap().is_empty());
 
     // Unknown token → 404.
     let req = Request::builder()
@@ -670,7 +670,8 @@ async fn test_guest_whip_malformed_offer() {
 async fn test_webrtc_config_default_and_update() {
     let (app, key, _s) = setup().await;
 
-    // Default config exposes at least one (STUN) ICE server.
+    // Default config has no ICE servers, so LAN and offline installs have no
+    // external dependency. STUN/TURN are opt-in.
     let resp = app
         .clone()
         .oneshot(json_request("GET", "/api/v1/webrtc/config", &key, None))
@@ -678,7 +679,7 @@ async fn test_webrtc_config_default_and_update() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let cfg = response_json(resp).await;
-    assert!(!cfg["ice_servers"].as_array().unwrap().is_empty());
+    assert!(cfg["ice_servers"].as_array().unwrap().is_empty());
 
     // Add a TURN server and read it back.
     let body = r#"{"ice_servers":[{"urls":["stun:stun.l.google.com:19302"]},{"urls":["turn:turn.example.com:3478"],"username":"u","credential":"p"}]}"#;


### PR DESCRIPTION
The default WebRTC config pointed at Google's public STUN server. For the self-host core that is an external dependency it should not carry, and on a LAN it is not needed and only produced resolver warnings in the logs.

Default to an empty ICE list. An encoder on the same LAN as the server connects with host candidates alone, so offline and air-gapped installs work with no external call. STUN and TURN stay configurable under the WebRTC settings for anyone publishing or running guests across NAT. TURN support and docs can follow in a later update.

Verified a WHIP H.264 ingest still goes live and reaches an RTMP destination with the empty default, and the STUN resolver warnings are gone.