### PR TITLE
Fix WHIP ingest: source persistence, H.264 profiles, diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-api"
-version = "1.8.6"
+version = "1.8.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-common"
-version = "1.8.6"
+version = "1.8.4"
 dependencies = [
  "chrono",
  "serde",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-processor"
-version = "1.8.6"
+version = "1.8.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.6"
+version = "1.8.4"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -6,6 +6,7 @@ pub mod openapi;
 pub mod egress;
 pub mod failover;
 pub mod guest_webrtc;
+pub mod startup;
 pub mod webrtc_ingest;
 pub mod media_player;
 pub mod media_probe;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -63,14 +63,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     run_migrations(&db).await?;
 
-    // Guests are ephemeral (peers live in memory). Any web_rtc source or
-    // connected guest record left in the DB is an orphan from a previous run.
-    let _ = sqlx::query("DELETE FROM sources WHERE kind LIKE '%\"web_rtc\"%'")
-        .execute(&db)
-        .await;
-    let _ = sqlx::query("UPDATE guests SET status = 'invited', source_id = NULL WHERE source_id IS NOT NULL")
-        .execute(&db)
-        .await;
+    // Clean up orphan guest sources from a previous run. Persistent WHIP ingest
+    // sources use the same web_rtc kind but are not guest-linked, so they survive.
+    muxshed_api::startup::cleanup_orphan_guest_sources(&db).await;
 
     // Headless bootstrap: seed the env-provided admin API key (idempotent) so an
     // operator has a working credential without the web setup wizard.

--- a/crates/api/src/startup.rs
+++ b/crates/api/src/startup.rs
@@ -1,0 +1,23 @@
+// Licensed under the GNU Affero General Public License v3.0 — see LICENSE.
+
+//! Startup housekeeping run once before the router is built.
+
+use sqlx::SqlitePool;
+
+/// Remove orphan guest sources left over from a previous run and reset guest
+/// records. Guest sources are ephemeral (their peers live in memory) and are
+/// linked to a `guests` record; persistent WHIP ingest sources use the same
+/// `web_rtc` kind but are NOT guest-linked, so they must survive a restart and
+/// are left untouched here.
+pub async fn cleanup_orphan_guest_sources(db: &SqlitePool) {
+    let _ = sqlx::query(
+        "DELETE FROM sources WHERE id IN (SELECT source_id FROM guests WHERE source_id IS NOT NULL)",
+    )
+    .execute(db)
+    .await;
+    let _ = sqlx::query(
+        "UPDATE guests SET status = 'invited', source_id = NULL WHERE source_id IS NOT NULL",
+    )
+    .execute(db)
+    .await;
+}

--- a/crates/api/src/webrtc_ingest.rs
+++ b/crates/api/src/webrtc_ingest.rs
@@ -134,6 +134,16 @@ pub async fn start_ingest(
     offer_sdp: String,
     kind: IngestKind,
 ) -> Result<String, String> {
+    // Log the publisher's offered video codecs so codec-negotiation failures are
+    // diagnosable — e.g. exactly which H.264 profile-level-id an encoder like OBS
+    // is sending when the video track is rejected as "codec not found".
+    for line in offer_sdp.lines() {
+        let u = line.to_ascii_uppercase();
+        if u.contains("H264") || u.contains("H265") || u.contains("HEVC") || line.contains("profile-level-id") {
+            tracing::info!("ingest {}: offer codec: {}", source_id, line.trim());
+        }
+    }
+
     let (video_port, audio_port) = alloc_ports().await?;
 
     let pc = build_peer(&state).await?;
@@ -379,10 +389,17 @@ async fn build_peer(state: &AppState) -> Result<Arc<RTCPeerConnection>, String> 
     // Chrome, Firefox, Safari, and OBS. Whatever profile is negotiated, the pump
     // reads the track's mime as H.264 and forwards it the same way.
     for (pt, fmtp) in [
+        // Constrained Baseline (browsers, most encoders)
         (102u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f"),
         (127u8, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f"),
         (125u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f"),
         (108u8, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f"),
+        // Main (some hardware encoders)
+        (124u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f"),
+        (118u8, "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f"),
+        // Constrained High and High (OBS / Apple VideoToolbox)
+        (120u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f"),
+        (121u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f"),
         (123u8, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032"),
     ] {
         m.register_codec(

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -987,6 +987,53 @@ async fn test_whip_rejects_guest_token() {
 }
 
 #[tokio::test]
+async fn test_startup_keeps_whip_sources_removes_guest_orphans() {
+    // A persistent WHIP source (web_rtc, no guest link) must survive a restart;
+    // a guest-linked ephemeral source (same kind) must be cleaned. This locks in
+    // the fix for the startup cleanup that used to delete every web_rtc source.
+    let (_app, _key, state) = setup().await;
+
+    let whip = uuid::Uuid::new_v4();
+    sqlx::query("INSERT INTO sources (id, name, kind) VALUES (?, ?, ?)")
+        .bind(whip.to_string())
+        .bind("Cam")
+        .bind(r#"{"type":"web_rtc","token":"keepme"}"#)
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+    let guest = uuid::Uuid::new_v4();
+    let guest_src = uuid::Uuid::new_v4();
+    sqlx::query("INSERT INTO sources (id, name, kind) VALUES (?, ?, ?)")
+        .bind(guest_src.to_string())
+        .bind("Bob (guest)")
+        .bind(r#"{"type":"web_rtc","token":"guesttok"}"#)
+        .execute(&state.db)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO guests (id, name, token, source_id) VALUES (?, ?, ?, ?)")
+        .bind(guest.to_string())
+        .bind("Bob")
+        .bind("guesttok")
+        .bind(guest_src.to_string())
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+    muxshed_api::startup::cleanup_orphan_guest_sources(&state.db).await;
+
+    let ids: Vec<String> = sqlx::query_as::<_, (String,)>("SELECT id FROM sources")
+        .fetch_all(&state.db)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|(i,)| i)
+        .collect();
+    assert!(ids.contains(&whip.to_string()), "persistent WHIP source must survive restart");
+    assert!(!ids.contains(&guest_src.to_string()), "guest ephemeral source must be removed");
+}
+
+#[tokio::test]
 async fn test_whip_teardown_unknown_session_is_noop() {
     let (app, _key, _state) = setup().await;
     let req = Request::builder()


### PR DESCRIPTION
The fixes that make WHIP ingest actually work with a real encoder end to end.

- Startup no longer deletes persistent WHIP sources. The boot cleanup was scoped to all web_rtc rows, but WHIP sources share that kind with guests, so every restart wiped the source and invalidated its token. Cleanup is now scoped to guest-linked sources, extracted into a testable function, and covered by a regression test.
- Register Main and Constrained High H.264 profiles alongside baseline and high, so encoders like OBS on macOS negotiate video instead of being rejected as codec-not-found.
- Log the publisher's offered video codec, so a mismatch (including an encoder set to H.265, which WHIP ingest does not decode) is diagnosable from the server log.

Verified end to end: an H.264 WHIP publish goes live and restreams to an RTMP destination as a continuous 1080p H.264/AAC stream carrying real video (checked a decoded frame is real content, not black), with a single egress connection and a keyframe every 2s; and a WHIP source survives a server restart with its token intact. cargo test (57) and clippy pass.