### PR TITLE
Compact source grid in the studio (v1.8.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-api"
-version = "1.8.4"
+version = "1.8.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-common"
-version = "1.8.4"
+version = "1.8.5"
 dependencies = [
  "chrono",
  "serde",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "muxshed-processor"
-version = "1.8.4"
+version = "1.8.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.4"
+version = "1.8.5"
 rust-version = "1.88"
 
 [workspace.dependencies]

--- a/web/src/routes/(app)/+page.svelte
+++ b/web/src/routes/(app)/+page.svelte
@@ -599,10 +599,10 @@
 					{#if liveStreamSources().length === 0}
 						<p class="text-amber-muted">No live sources. Connect OBS to start.</p>
 					{:else}
-						<div class="grid gap-3" style="grid-template-columns: repeat({Math.min(liveStreamSources().length, 3)}, minmax(0, 1fr))">
+						<div class="grid gap-2" style="grid-template-columns: repeat(auto-fill, minmax(200px, 1fr))">
 							{#each liveStreamSources() as source (source.id)}
 								<div
-									class="rounded-sm border p-2 transition-colors {source.id === programSourceId
+									class="rounded-sm border p-1.5 transition-colors {source.id === programSourceId
 										? 'border-danger bg-panel-raised'
 										: source.id === previewSourceId
 											? 'border-live bg-panel-raised'
@@ -613,18 +613,18 @@
 										label={source.name}
 										active={source.id === programSourceId}
 									/>
-									<div class="mt-2 flex gap-2">
+									<div class="mt-1.5 flex gap-1.5">
 										<button
 											onclick={() => { previewSourceId = source.id; }}
 											disabled={source.id === programSourceId}
-											class="btn flex-1 {source.id === previewSourceId ? 'btn--go' : ''}"
+											class="btn flex-1 px-2 py-1 text-[10px] {source.id === previewSourceId ? 'btn--go' : ''}"
 										>
 											Next Up
 										</button>
 										<button
 											onclick={() => cutToSource(source.id)}
 											disabled={source.id === programSourceId}
-											class="btn btn--danger flex-1"
+											class="btn btn--danger flex-1 px-2 py-1 text-[10px]"
 										>
 											Switch
 										</button>


### PR DESCRIPTION
The studio Sources tab stretched source tiles across up to three full-width columns, so one or two sources filled the whole panel and a larger roster got unwieldy. Switch to a fixed-width auto-fill grid: 200px thumbnails that wrap into rows, with tighter Next Up / Switch buttons, so many sources stay scannable at a glance.

Type-check and build pass.